### PR TITLE
Azure-pipelines integration

### DIFF
--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -45,11 +45,10 @@ steps:
   - bash: |
       coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
       coverage xml
-      rm -rf cyclonedds
     name: collect_test_coverage
     displayName: Collect PyCDR and CycloneDDS coverage data
   - bash: |
-      python -m codecov -t $token
+      python -m codecov -t $token -f coverage.xml
     name: submit_to_codecov
     displayName: Upload to codecov
     env:

--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -43,7 +43,44 @@ steps:
       coverage xml
     name: collect_test_coverage
     displayName: Collect PyCDR and CycloneDDS coverage data
-  - bash:
-      bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN) -f coverage.xml
-    name: codecov_upload
-    displayName: Upload to Codecov
+  - bash: |
+      set -e -x
+      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
+      commit="${BUILD_SOURCEVERSION}"
+      if [ -n "$pr" ] && [ "$pr" != false ]; then
+        mc=$(git show --no-patch --format="%P" 2>/dev/null || echo "")
+        if [[ "$mc" =~ ^[a-z0-9]{40}[[:space:]][a-z0-9]{40}$ ]]; then
+          mc=$(echo "$mc" | cut -d ' ' -f2)
+          commit=$mc
+        fi
+      fi
+      query=$(curl -Gso /dev/null -w "%{url_effective}" "" \
+        --data-urlencode "package=cmake-codecov.io" \
+        --data-urlencode "token=${token}" \
+        --data-urlencode "branch=${BUILD_SOURCEBRANCH#/refs/heads/}" \
+        --data-urlencode "commit=${commit}" \
+        --data-urlencode "build=${BUILD_BUILDNUMBER}" \
+        --data-urlencode "build_url=${SYSTEM_TEAMFOUNDATIONSERVERURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}" \
+        --data-urlencode "tag=" \
+        --data-urlencode "slug=${slug}" \
+        --data-urlencode "service=azure_pipelines" \
+        --data-urlencode "flags=" \
+        --data-urlencode "pr=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-$SYSTEM_PULLREQUEST_PULLREQUESTID}" \
+        --data-urlencode "job=${BUILD_BUILDID}" \
+        --data-urlencode "project=${SYSTEM_TEAMPROJECT}" \
+        --data-urlencode "server_uri=${SYSTEM_TEAMFOUNDATIONSERVERURI}" \
+        2>/dev/null | cut -c 3- | sed -e 's/%0A//')
+      tar -czf coverage.tar.gz coverage.xml src/*
+      code=$(curl -X POST -w "%{http_code}" \
+        --data-binary @"coverage.tar.gz" \
+        --retry 5 --retry-delay 2 --connect-timeout 2 \
+        -H 'Content-Type: text/plain' \
+        -H 'Content-Encoding: gzip' \
+        -H 'X-Content-Encoding: gzip' \
+        -H 'Accept: text/plain' \
+        "https://codecov.io/upload/v2?$query")
+      [[ "${code}" =~ "success" ]] || (echo "cURL exited with ${code}" 1>&2 && exit 1)
+    name: submit_to_codecov
+    displayName: Upload to codecov
+    env:
+      token: $(CODECOV_TOKEN)

--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -39,47 +39,16 @@ steps:
     displayName: Set CYCLONEDDS_HOME
   - template: /.azure/templates/build-test.yml
   - bash: |
+      pip install "git+https://github.com/thijsmie/codecov-python#egg=codecov"
+    name: install_codecov_python
+    displayName: Install Codecov-python
+  - bash: |
       coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
       coverage xml
     name: collect_test_coverage
     displayName: Collect PyCDR and CycloneDDS coverage data
   - bash: |
-      set -e -x
-      slug=$(echo "${BUILD_REPOSITORY_URI}" | sed -nE 's#.*/([^/]+/[^\]+)#\1#p')
-      commit="${BUILD_SOURCEVERSION}"
-      if [ -n "$pr" ] && [ "$pr" != false ]; then
-        mc=$(git show --no-patch --format="%P" 2>/dev/null || echo "")
-        if [[ "$mc" =~ ^[a-z0-9]{40}[[:space:]][a-z0-9]{40}$ ]]; then
-          mc=$(echo "$mc" | cut -d ' ' -f2)
-          commit=$mc
-        fi
-      fi
-      query=$(curl -Gso /dev/null -w "%{url_effective}" "" \
-        --data-urlencode "package=cmake-codecov.io" \
-        --data-urlencode "token=${token}" \
-        --data-urlencode "branch=${BUILD_SOURCEBRANCH#/refs/heads/}" \
-        --data-urlencode "commit=${commit}" \
-        --data-urlencode "build=${BUILD_BUILDNUMBER}" \
-        --data-urlencode "build_url=${SYSTEM_TEAMFOUNDATIONSERVERURI}${SYSTEM_TEAMPROJECT}/_build/results?buildId=${BUILD_BUILDID}" \
-        --data-urlencode "tag=" \
-        --data-urlencode "slug=${slug}" \
-        --data-urlencode "service=azure_pipelines" \
-        --data-urlencode "flags=" \
-        --data-urlencode "pr=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-$SYSTEM_PULLREQUEST_PULLREQUESTID}" \
-        --data-urlencode "job=${BUILD_BUILDID}" \
-        --data-urlencode "project=${SYSTEM_TEAMPROJECT}" \
-        --data-urlencode "server_uri=${SYSTEM_TEAMFOUNDATIONSERVERURI}" \
-        2>/dev/null | cut -c 3- | sed -e 's/%0A//')
-      tar -czf coverage.tar.gz coverage.xml src/*
-      code=$(curl -X POST -w "%{http_code}" \
-        --data-binary @"coverage.tar.gz" \
-        --retry 5 --retry-delay 2 --connect-timeout 2 \
-        -H 'Content-Type: text/plain' \
-        -H 'Content-Encoding: gzip' \
-        -H 'X-Content-Encoding: gzip' \
-        -H 'Accept: text/plain' \
-        "https://codecov.io/upload/v2?$query")
-      [[ "${code}" =~ "success" ]] || (echo "cURL exited with ${code}" 1>&2 && exit 1)
+      python -m codecov -t $token
     name: submit_to_codecov
     displayName: Upload to codecov
     env:

--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -1,0 +1,49 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Azure Pipeline specifically for building and submitting to Codecov
+#
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 12 * * 0"
+    branches:
+      include: [ master ]
+    always: false
+
+pool:
+  vmImage: ubuntu-20.04
+
+variables:
+- group: Default
+- name: python-version
+  value: 3.9
+
+steps:
+  - template: /.azure/templates/build-cyclone.yml
+  - bash: |
+      echo "###vso[task.setvariable variable=cyclonedds_home;]$(pwd)/cyclone-$(Agent.OS)"
+    name: set_cyclonedds_home
+    displayName: Set CYCLONEDDS_HOME
+  - template: /.azure/templates/build-test.yml
+  - bash: |
+      coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
+      coverage xml
+    name: collect_test_coverage
+    displayName: Collect PyCDR and CycloneDDS coverage data
+  - bash:
+      bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN) -f coverage.xml
+    name: codecov_upload
+    displayName: Upload to Codecov

--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -45,6 +45,7 @@ steps:
   - bash: |
       coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
       coverage xml
+      rm -rf cyclonedds
     name: collect_test_coverage
     displayName: Collect PyCDR and CycloneDDS coverage data
   - bash: |

--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -17,7 +17,7 @@
 trigger:
   tags:
     include:
-    - 'v*'
+    - '*'
 
 variables:
 - group: Default

--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -1,0 +1,30 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Azure Pipeline publishing packages
+#
+
+trigger:
+  tags:
+    include:
+    - 'v*'
+
+variables:
+- group: Default
+
+jobs:
+- job: PublishPackage
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - template: /.azure/templates/publish-package.yml

--- a/.azure/templates/build-cyclone.yml
+++ b/.azure/templates/build-cyclone.yml
@@ -1,0 +1,62 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Template to build and cache CycloneDDS for use in python testing
+#
+
+steps:
+  - bash: |
+      git clone https://github.com/eclipse-cyclonedds/cyclonedds.git
+    name: clone_cyclone
+    displayName: Clone the CycloneDDS repository
+  - task: Cache@2
+    inputs:
+      key: cyclonedds_build | 2 | $(Agent.OS) | cyclonedds/.git/refs/heads/master
+      path: cyclone-$(Agent.OS)
+      cacheHitVar: CACHE_RESTORED
+    name: cyclonedds_cache
+    displayName: Check for a build cache
+  - bash: |
+      echo "###vso[task.setvariable variable=build_tool_options;]-j 4"
+    condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables.CACHE_RESTORED, 'true'))
+    name: setup_linux
+    displayName: Setup for Linux builds
+  - bash: |
+      sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+      echo "###vso[task.setvariable variable=build_tool_options;]-j 4"
+      brew install bison
+    condition: and(eq(variables['Agent.OS'], 'Darwin'), ne(variables.CACHE_RESTORED, 'true'))
+    name: setup_macos
+    displayName: Setup for MacOS builds
+  - pwsh: |
+      $python_bin = python -m site --user-base
+      Write-Host "###vso[task.setvariable variable=build_tool_options;]-nologo -verbosity:minimal -maxcpucount:4 -p:CL_MPCount=4"
+      choco install winflexbison3
+    condition: and(eq(variables['Agent.OS'], 'Windows_NT'), ne(variables.CACHE_RESTORED, 'true'))
+    name: setup_windows
+    displayName: Setup for Windows builds
+  - bash: |
+      set -e -x
+      mkdir -p cyclonedds/build cyclone-$(Agent.OS)
+      cd cyclonedds/build
+      cmake -DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+            -DCMAKE_INSTALL_PREFIX=../../cyclone-$(Agent.OS) \
+            -DENABLE_LIFESPAN=ON \
+            -DENABLE_DEADLINE_MISSED=ON \
+            -DENABLE_TYPE_DISCOVERY=ON \
+            -DENABLE_TOPIC_DISCOVERY=ON \
+            ..
+      cmake --build . --target install -- ${BUILD_TOOL_OPTIONS}
+    name: cyclonedds_build
+    displayName: Build CycloneDDS
+    condition: ne(variables.CACHE_RESTORED, 'true')

--- a/.azure/templates/build-cyclone.yml
+++ b/.azure/templates/build-cyclone.yml
@@ -19,10 +19,15 @@ steps:
       git clone https://github.com/eclipse-cyclonedds/cyclonedds.git
     name: clone_cyclone
     displayName: Clone the CycloneDDS repository
+  - bash: |
+      [[ -n "${BUILD_TYPE}" ]] || \
+        echo "###vso[task.setvariable variable=build_type;]RelWithDebugInfo"
+    name: build_type_setter
+    displayName: Check the build type.
   - task: Cache@2
     inputs:
-      key: cyclonedds_build | 2 | $(Agent.OS) | cyclonedds/.git/refs/heads/master
-      path: cyclone-$(Agent.OS)
+      key: cyclonedds_build | 4 | $(Agent.OS) | $(build_type) | cyclonedds/.git/refs/heads/master
+      path: cyclone-$(Agent.OS)-$(build_type)
       cacheHitVar: CACHE_RESTORED
     name: cyclonedds_cache
     displayName: Check for a build cache
@@ -47,10 +52,10 @@ steps:
     displayName: Setup for Windows builds
   - bash: |
       set -e -x
-      mkdir -p cyclonedds/build cyclone-$(Agent.OS)
+      mkdir -p cyclonedds/build cyclone-$(Agent.OS)-$(build_type)
       cd cyclonedds/build
-      cmake -DCMAKE_BUILD_TYPE=RelWithDebugInfo \
-            -DCMAKE_INSTALL_PREFIX=../../cyclone-$(Agent.OS) \
+      cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_INSTALL_PREFIX=../../cyclone-$(Agent.OS)-$(build_type) \
             -DENABLE_LIFESPAN=ON \
             -DENABLE_DEADLINE_MISSED=ON \
             -DENABLE_TYPE_DISCOVERY=ON \

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -23,6 +23,7 @@ steps:
     displayName: Install Python $(python-version)
   - bash: |
       set -e -x
+      pip install pip --upgrade
       pip install pytest pytest-azurepipelines pytest-cov flake8
       pip install ./src/pycdr
       pip install ./src/cyclonedds
@@ -34,7 +35,7 @@ steps:
       flake8 ./src/pycdr/pycdr --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
       flake8 ./src/cyclonedds/cyclonedds --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
     name: flake8_lint
-    displayName: Run linter
+    displayName: Run Flake8 Linter
   - bash: |
       cd ./src/pycdr
       pytest --no-coverage-upload

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -1,0 +1,47 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Run pytest testing
+#
+
+steps:
+  # We test for different python versions
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python-version)'
+    name: install_python
+    displayName: Install Python $(python-version)
+  - bash: |
+      set -e -x
+      pip install pytest pytest-azurepipelines pytest-cov flake8
+      pip install ./src/pycdr
+      pip install ./src/cyclonedds
+    name: install_cyclonedds_py
+    displayName: Run installers
+  - bash: |
+      flake8 ./src/pycdr/pycdr --count --select=E9,F63,F7,F82 --show-source --statistics
+      flake8 ./src/cyclonedds/cyclonedds --count --select=E9,F63,F7,F82 --show-source --statistics
+      flake8 ./src/pycdr/pycdr --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
+      flake8 ./src/cyclonedds/cyclonedds --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
+    name: flake8_lint
+    displayName: Run linter
+  - bash: |
+      cd ./src/pycdr
+      pytest --no-coverage-upload
+    name: test_pycdr
+    displayName: Run tests for PyCDR
+  - bash: |
+      cd ./src/cyclonedds
+      pytest --no-coverage-upload
+    name: test_cyclonedds_py
+    displayName: Run tests for CycloneDDS

--- a/.azure/templates/publish-package.yml
+++ b/.azure/templates/publish-package.yml
@@ -1,0 +1,51 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Publish dist with twine
+#
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.9'
+    name: install_python
+    displayName: Fetch Python 3.9
+  - bash: |
+      set -e -x
+      pip install twine
+    name: install_twine
+    displayName: Install Twine
+  - bash: |
+      cd ./src/pycdr
+      python setup.py sdist
+    name: build_pycdr_src_dist
+    displayName: Build PyCDR source distribution
+  - bash: |
+      cd ./src/cyclonedds
+      python setup.py sdist
+    name: build_cyclonedds_src_dist
+    displayName: Build CycloneDDS source distribution
+  - task: DownloadSecureFile@1
+    name: pypi_credentials
+    inputs:
+      secureFile: pypi_credentials
+  - bash: |
+      cd ./src/pycdr
+      python -m twine upload -r $(PYPI_REPOSITORY) --config-file $(pypi_credentials.secureFilePath) --skip-existing dist/*
+    name: publish_pycdr
+    displayName: Publish PyCDR
+  - bash: |
+      cd ./src/cyclonedds
+      python -m twine upload -r $(PYPI_REPOSITORY) --config-file $(pypi_credentials.secureFilePath) --skip-existing dist/*
+    name: publish_cyclonedds
+    displayName: Publish CycloneDDS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,10 +26,13 @@ jobs:
         image: macOS-10.15
       'Windows Server 2019':
         image: windows-2019
+      'Windows Server 2019 Debug':
+        image: windows-2019
+        build_type: Debug
   steps:
   - template: /.azure/templates/build-cyclone.yml
-  - publish: cyclone-$(Agent.OS)
-    artifact: cyclone-$(Agent.OS)
+  - publish: cyclone-$(Agent.OS)-$(build_type)
+    artifact: cyclone-$(Agent.OS)-$(build_type)
 - job: AutomatedTests
   dependsOn: BuildCyclone
   pool:
@@ -54,12 +57,20 @@ jobs:
       'Windows Server 2019 with Python 3.9':
         image: windows-2019
         python-version: 3.9
+      'Windows Server 2019, Cyclone Debug, with Python 3.9':
+        image: windows-2019
+        python-version: 3.9
+        build_type: Debug
   steps:
-  - download: current
-    artifact: cyclone-$(Agent.OS)
   - bash: |
-      echo "###vso[task.setvariable variable=cyclonedds_home;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)"
+      [[ -n "${BUILD_TYPE}" ]] || \
+        echo "###vso[task.setvariable variable=build_type;]RelWithDebugInfo"
+    name: build_type_setter
+    displayName: Check the build type.
+  - download: current
+    artifact: cyclone-$(Agent.OS)-$(build_type)
+  - bash: |
+      echo "###vso[task.setvariable variable=cyclonedds_home;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)-$(build_type)"
     name: set_cyclonedds_home
     displayName: Set CYCLONEDDS_HOME
   - template: /.azure/templates/build-test.yml
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,65 @@
+#
+# Copyright(c) 2021 ADLINK Technology Limited and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+# v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+trigger: [ '*' ]
+pr: [ '*' ]
+
+
+jobs:
+- job: BuildCyclone
+  pool:
+    vmImage: $(image)
+  strategy:
+    matrix:
+      'Ubuntu 20.04 LTS':
+        image: ubuntu-20.04
+      'macOS 10.15':
+        image: macOS-10.15
+      'Windows Server 2019':
+        image: windows-2019
+  steps:
+  - template: /.azure/templates/build-cyclone.yml
+  - publish: cyclone-$(Agent.OS)
+    artifact: cyclone-$(Agent.OS)
+- job: AutomatedTests
+  dependsOn: BuildCyclone
+  pool:
+    vmImage: $(image)
+  strategy:
+    matrix:
+      'Ubuntu 20.04 LTS with Python 3.6':
+        image: ubuntu-20.04
+        python-version: 3.6
+      'Ubuntu 20.04 LTS with Python 3.7':
+        image: ubuntu-20.04
+        python-version: 3.7
+      'Ubuntu 20.04 LTS with Python 3.8':
+        image: ubuntu-20.04
+        python-version: 3.8
+      'Ubuntu 20.04 LTS with Python 3.9':
+        image: ubuntu-20.04
+        python-version: 3.9
+      'macOS 10.15 with Python 3.9':
+        image: macOS-10.15
+        python-version: 3.9
+      'Windows Server 2019 with Python 3.9':
+        image: windows-2019
+        python-version: 3.9
+  steps:
+  - download: current
+    artifact: cyclone-$(Agent.OS)
+  - bash: |
+      echo "###vso[task.setvariable variable=cyclonedds_home;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)"
+    name: set_cyclonedds_home
+    displayName: Set CYCLONEDDS_HOME
+  - template: /.azure/templates/build-test.yml
+

--- a/src/cyclonedds/clayer/src/pysertype.c
+++ b/src/cyclonedds/clayer/src/pysertype.c
@@ -1522,25 +1522,35 @@ ddspy_take_endpoint(PyObject *self, PyObject *args)
             PyErr_SetString(PyExc_Exception, "Sampleinfo errored.");
             return NULL;
         }
-        PyObject* qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
-            PyErr_SetString(PyExc_Exception, "VoidPtr errored.");
-            return NULL;
-        }
-        PyObject* qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
-        if (PyErr_Occurred()) {
-            PyErr_Clear();
-            PyErr_SetString(PyExc_Exception, "Callfunc cqos errored.");
-            return NULL;
+
+        PyObject* qos_p, *qos;
+
+        if (rcontainer[i]->qos != NULL) {
+            qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
+            if (PyErr_Occurred()) {
+                PyErr_Clear();
+                PyErr_SetString(PyExc_Exception, "VoidPtr errored.");
+                return NULL;
+            }
+            qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
+            if (PyErr_Occurred()) {
+                PyErr_Clear();
+                PyErr_SetString(PyExc_Exception, "Callfunc cqos errored.");
+                return NULL;
+            }
+        } else {
+            Py_INCREF(Py_None);
+            Py_INCREF(Py_None);
+            qos_p = Py_None;
+            qos = Py_None;
         }
         PyObject* item = PyObject_CallFunction( \
             endpoint_constructor, "y#y#Ks#s#OO", \
             rcontainer[i]->key.v, (Py_ssize_t) 16, \
             rcontainer[i]->participant_key.v, (Py_ssize_t) 16, \
             rcontainer[i]->participant_instance_handle,
-            rcontainer[i]->topic_name, strlen(rcontainer[i]->topic_name),
-            rcontainer[i]->type_name, strlen(rcontainer[i]->type_name),
+            rcontainer[i]->topic_name, rcontainer[i]->topic_name == NULL ? 0 : strlen(rcontainer[i]->topic_name),
+            rcontainer[i]->type_name, rcontainer[i]->type_name == NULL ? 0 : strlen(rcontainer[i]->type_name),
             qos,
             sampleinfo
         );

--- a/src/cyclonedds/clayer/src/pysertype.c
+++ b/src/cyclonedds/clayer/src/pysertype.c
@@ -1346,9 +1346,13 @@ ddspy_read_participant(PyObject *self, PyObject *args)
 
     for(int i = 0; i < (sts > N ? N : sts); ++i) {
         PyObject* sampleinfo = get_sampleinfo_pyobject(&info[i]);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* item = PyObject_CallFunction(participant_constructor, "y#OO", rcontainer[i]->key.v, 16, qos, sampleinfo);
+        if (PyErr_Occurred()) { return NULL; }
         PyList_SetItem(list, i, item); // steals ref
         Py_DECREF(sampleinfo);
         Py_DECREF(qos_p);
@@ -1396,9 +1400,13 @@ ddspy_take_participant(PyObject *self, PyObject *args)
 
     for(int i = 0; i < (sts > N ? N : sts); ++i) {
         PyObject* sampleinfo = get_sampleinfo_pyobject(&info[i]);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* item = PyObject_CallFunction(participant_constructor, "y#OO", rcontainer[i]->key.v, 16, qos, sampleinfo);
+        if (PyErr_Occurred()) { return NULL; }
         PyList_SetItem(list, i, item); // steals ref
         Py_DECREF(sampleinfo);
         Py_DECREF(qos_p);
@@ -1446,8 +1454,11 @@ ddspy_read_endpoint(PyObject *self, PyObject *args)
 
     for(int i = 0; i < (sts > N ? N : sts); ++i) {
         PyObject* sampleinfo = get_sampleinfo_pyobject(&info[i]);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
+        if (PyErr_Occurred()) { return NULL; }
         PyObject* item = PyObject_CallFunction( \
             endpoint_constructor, "y#y#KssOO", \
             rcontainer[i]->key.v, 16, \
@@ -1458,6 +1469,7 @@ ddspy_read_endpoint(PyObject *self, PyObject *args)
             qos,
             sampleinfo
         );
+        if (PyErr_Occurred()) { return NULL; }
         PyList_SetItem(list, i, item); // steals ref
         Py_DECREF(sampleinfo);
         Py_DECREF(qos_p);
@@ -1505,18 +1517,38 @@ ddspy_take_endpoint(PyObject *self, PyObject *args)
 
     for(int i = 0; i < (sts > N ? N : sts); ++i) {
         PyObject* sampleinfo = get_sampleinfo_pyobject(&info[i]);
+        if (PyErr_Occurred()) { 
+            PyErr_Clear();
+            PyErr_SetString(PyExc_Exception, "Sampleinfo errored.");
+            return NULL;
+        }
         PyObject* qos_p = PyLong_FromVoidPtr(rcontainer[i]->qos);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            PyErr_SetString(PyExc_Exception, "VoidPtr errored.");
+            return NULL;
+        }
         PyObject* qos = PyObject_CallFunction(cqos_to_qos, "O", qos_p);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            PyErr_SetString(PyExc_Exception, "Callfunc cqos errored.");
+            return NULL;
+        }
         PyObject* item = PyObject_CallFunction( \
-            endpoint_constructor, "y#y#KssOO", \
-            rcontainer[i]->key.v, 16, \
-            rcontainer[i]->participant_key.v, 16, \
+            endpoint_constructor, "y#y#Ks#s#OO", \
+            rcontainer[i]->key.v, (Py_ssize_t) 16, \
+            rcontainer[i]->participant_key.v, (Py_ssize_t) 16, \
             rcontainer[i]->participant_instance_handle,
-            rcontainer[i]->topic_name,
-            rcontainer[i]->type_name,
+            rcontainer[i]->topic_name, strlen(rcontainer[i]->topic_name),
+            rcontainer[i]->type_name, strlen(rcontainer[i]->type_name),
             qos,
             sampleinfo
         );
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            PyErr_SetString(PyExc_Exception, "Callfunc endpoint constructor errored.");
+            return NULL;
+        }
         PyList_SetItem(list, i, item); // steals ref
         Py_DECREF(sampleinfo);
         Py_DECREF(qos_p);

--- a/src/cyclonedds/setup.py
+++ b/src/cyclonedds/setup.py
@@ -24,15 +24,15 @@ if "CYCLONEDDS_HOME" in os.environ:
         library_dirs=[os.path.join(home, "lib"), os.path.join(home, "bin")]
     )
 else:
-    ddspy = Extension('ddspy', 
-        sources = ['clayer/src/pysertype.c', 'clayer/src/cdrkeyvm.c'], 
+    ddspy = Extension('ddspy',
+        sources = ['clayer/src/pysertype.c', 'clayer/src/cdrkeyvm.c'],
         libraries=['ddsc'],
         include_dirs=['clayer/src']
     )
 
 setup(
     name='cyclonedds',
-    version='0.1.0',
+    version='0.1.1',
     description='Cyclone DDS Python binding',
     author='Thijs Miedema',
     author_email='thijs.miedema@adlinktech.com',

--- a/src/pycdr/setup.py
+++ b/src/pycdr/setup.py
@@ -31,7 +31,7 @@ else:
 
 setup(
     name='pycdr',
-    version='0.1.5',
+    version='0.1.6',
     description='Python CDR serialization',
     install_requires=REQUIRES,
     author='Thijs Miedema',


### PR DESCRIPTION
This commit adds the pipelines to test, lint, publish and report coverage. Building and publishing documentation will follow as soon as we have set it up on the C side.
To merge this a few extra external steps are required:

- Set up the repo in azure-pipelines
- Add a CODECOV_TOKEN environment variable
- Add a pypi_credentials secure file for publishing
- Add a PYPI_REPOSITORY environment variable for publishing

The last two can wait, the pipeline won't run until we tag a release.

For a full example of the pipeline runs see: https://dev.azure.com/tmiedema/cyclonedds-python/_build/results?buildId=109&view=results

N.B. There are a few actual C code changes in this pull request as well. These fix a bug introduced by the segfault fix that only occurs on windows by what I can only assume is wonky compiler behaviour.