### PR TITLE
Update PyCDR packaging strategy

### DIFF
--- a/src/pycdr/setup.cfg
+++ b/src/pycdr/setup.cfg
@@ -1,0 +1,36 @@
+[metadata]
+name = pycdr
+version = 0.1.5
+author = Thijs Miedema
+author_email = thijs.miedema@adlinktech.com
+description = Python CDR serialization
+url = https://github.com/eclipse-cyclone/cyclonedds-python
+project_urls =
+    Bug Tracker = https://github.com/eclipse-cyclone/cyclonedds-python/issues
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Operating System :: OS Independent
+
+[options]
+zip_safe = True
+include_package_data = False
+packages = find:
+python_requires = >=3.6
+install_requires =
+    dataclasses>=0.8; python_version < "3.7"
+    typing-inspect>=0.6; python_version < "3.7"
+    typing-extensions>=3.7; python_version < "3.9"
+
+[options.extras_require]
+dev = pytest; pytest-cov; flake8
+
+[options.packages.find]
+exclude =
+    tests
+    examples

--- a/src/pycdr/setup.cfg
+++ b/src/pycdr/setup.cfg
@@ -10,6 +10,7 @@ project_urls =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)
+    License :: OSI Approved :: BSD License  # BSD-Clause-3 is intended here
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/src/pycdr/setup.py
+++ b/src/pycdr/setup.py
@@ -10,46 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 """
+from setuptools import setup
 
-import os
-import sys
-from setuptools import setup, find_packages
-
-
-if sys.version_info < (3, 6):
-    sys.exit("This package cannot be installed in Python version 3.5 or lower.")
-elif sys.version_info < (3, 7):
-    # We are in any Python 3.6 version
-    REQUIRES = ['dataclasses==0.8', 'typing-extensions==3.7.4.3', 'typing-inspect==0.6.0']
-elif sys.version_info < (3, 9):
-    # We are in any Python 3.7 or 3.8 version
-    REQUIRES = ['typing-extensions==3.7.4.3']
-else:
-    # We are in any Python 3.9 or 3.10 (maybe higher?) version, no requirements
-    REQUIRES = []
-
-
-setup(
-    name='pycdr',
-    version='0.1.5',
-    description='Python CDR serialization',
-    install_requires=REQUIRES,
-    author='Thijs Miedema',
-    author_email='thijs.miedema@adlinktech.com',
-    url="https://github.com/thijsmie/cdds-py",
-    project_urls={
-        "Bug Tracker": "https://github.com/thijsmie/cdds-py/issues"
-    },
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Operating System :: OS Independent"
-    ],
-    packages=find_packages(exclude=("tests", "examples")),
-    python_requires='>=3.6'
-)
+setup()


### PR DESCRIPTION
PyCDR does not need any complicated setup so this PR updates it to use the newer `setup.cfg` method. `setup.py` is still present as empty shell to allow older (v18 and below) pip distributions to still use the installer.