### PR TITLE
Fix issue #5

### DIFF
--- a/src/cyclonedds/cyclonedds/core.py
+++ b/src/cyclonedds/cyclonedds/core.py
@@ -744,7 +744,7 @@ class Listener(DDS):
 
         if _is_override(self.on_sample_rejected):
             self.set_on_sample_rejected(self.on_sample_rejected)
-            self._set_functors["on_data_available"] = self.on_data_available
+            self._set_functors["on_sample_rejected"] = self.on_sample_rejected
 
         if _is_override(self.on_requested_deadline_missed):
             self.set_on_requested_deadline_missed(self.on_requested_deadline_missed)


### PR DESCRIPTION
This functor map is never used for lookups, but purely to avoid Python GC'ing the function if a pointer is passed to the C layer but the original owner of the callable is freed. Thus this mistake can lead, in very rare cases, to a segfault because the C layer will call a freed Python function.