### PR TITLE
Keyless semantics

### DIFF
--- a/src/cyclonedds/tests/conftest.py
+++ b/src/cyclonedds/tests/conftest.py
@@ -66,14 +66,14 @@ class Manual:
 
     def dw(self, qos=None, listener=None):
         self._dw = DataWriter(
-            self._pub if self._pub else self.pub(), 
+            self._pub if self._pub else self.pub(),
             self._tp if self._tp else self.tp(),
             qos=qos, listener=listener)
         return self._dw
 
     def dr(self, qos=None, listener=None):
         self._dr = DataReader(
-            self._sub if self._sub else self.sub(), 
+            self._sub if self._sub else self.sub(),
             self._tp if self._tp else self.tp(),
             qos=qos, listener=listener)
         return self._dr

--- a/src/cyclonedds/tests/test_listener.py
+++ b/src/cyclonedds/tests/test_listener.py
@@ -167,7 +167,7 @@ def test_on_requested_deadline_missed(manual_setup, hitpoint):
     qos = Qos(Policy.Deadline(duration(seconds=0.2)))
     datawriter = manual_setup.dw(qos=qos)
     manual_setup.dr(qos=qos, listener=MyListener())
-    
+
     write_time = timestamp.now()
     datawriter.write(manual_setup.msg)
 
@@ -180,7 +180,6 @@ def test_on_sample_rejected(manual_setup, hitpoint):
         def on_sample_rejected(self, reader, status):
             hitpoint.hit()
 
-    
     qos = Qos(Policy.ResourceLimits(max_samples=1))
 
     datawriter = manual_setup.dw()
@@ -199,10 +198,10 @@ def test_on_sample_lost(manual_setup, hitpoint):
             hitpoint.hit()
 
     qos = Qos(Policy.DestinationOrder.BySourceTimestamp)
-    
+
     datawriter = manual_setup.dw(qos=qos)
     datareader = manual_setup.dr(qos=qos, listener=MyListener())
-   
+
     t1 = timestamp.now()
     t2 = t1 + duration(seconds=1)
 

--- a/src/pycdr/pycdr/__init__.py
+++ b/src/pycdr/pycdr/__init__.py
@@ -12,13 +12,13 @@
 
 from dataclasses import dataclass
 
-from .main import CDR, proto_deserialize, proto_serialize, Endianness
+from .main import CDR, proto_deserialize, proto_serialize
 
 
-def cdr(*args, final=True, mutable=False, appendable=False, keylist=None):
+def cdr(*args, **kwargs):
     def in_cdr(cls):
         cls = dataclass(cls)
-        CDR(cls, final=final, mutable=mutable, appendable=appendable, keylist=keylist)
+        CDR(cls, **kwargs)
         cls.serialize = proto_serialize
         cls.deserialize = classmethod(proto_deserialize)
         return cls

--- a/src/pycdr/pycdr/builder.py
+++ b/src/pycdr/pycdr/builder.py
@@ -127,10 +127,14 @@ class Builder:
                 raise BuildDefer(module_prefix + key)
             else:
                 raise BuildDefer(key)
+
+        if not _type.cdr.keyless and _type.cdr.keylist is None:
+            _type.cdr.keylist = fields.keys()  # here .keys() gives dict keys
+
         members = {
             name: cls._machine_for_type(module_prefix, field_type, key)
             for name, field_type in fields.items()
-            if not key or _type.cdr.keyless or name in _type.cdr.keylist
+            if not key or (not _type.cdr.keyless and name in _type.cdr.keylist)
         }
         return StructMachine(_type, members)
 

--- a/src/pycdr/pycdr/builder.py
+++ b/src/pycdr/pycdr/builder.py
@@ -128,13 +128,13 @@ class Builder:
             else:
                 raise BuildDefer(key)
 
-        if not _type.cdr.keyless and _type.cdr.keylist is None:
+        if _type.cdr.keylist is None:
             _type.cdr.keylist = fields.keys()  # here .keys() gives dict keys
 
         members = {
             name: cls._machine_for_type(module_prefix, field_type, key)
             for name, field_type in fields.items()
-            if not key or (not _type.cdr.keyless and name in _type.cdr.keylist)
+            if not key or name in _type.cdr.keylist
         }
         return StructMachine(_type, members)
 

--- a/src/pycdr/pycdr/machinery.py
+++ b/src/pycdr/pycdr/machinery.py
@@ -420,7 +420,7 @@ class StructMachine(Machine):
     def cdr_key_machine_op(self, skip):
         return sum(
             (
-                m.cdr_key_machine_op(skip or self.type.cdr.keyless or name not in self.type.cdr.keylist)
+                m.cdr_key_machine_op(skip or name not in self.type.cdr.keylist)
                 for name, m in self.members_machines.items()
             ),
             []

--- a/src/pycdr/pycdr/machinery.py
+++ b/src/pycdr/pycdr/machinery.py
@@ -420,7 +420,7 @@ class StructMachine(Machine):
     def cdr_key_machine_op(self, skip):
         return sum(
             (
-                m.cdr_key_machine_op(skip or (not self.type.cdr.keyless and name not in self.type.cdr.keylist))
+                m.cdr_key_machine_op(skip or self.type.cdr.keyless or name not in self.type.cdr.keylist)
                 for name, m in self.members_machines.items()
             ),
             []

--- a/src/pycdr/pycdr/main.py
+++ b/src/pycdr/pycdr/main.py
@@ -18,7 +18,7 @@ from .builder import Builder
 
 class CDR:
     def __init__(self, datatype, final=True, mutable=False, appendable=False, nested=False, \
-                 autoid_hash=False, keylist=None, keyless=False):
+                 autoid_hash=False, keylist=None):
         self.buffer = Buffer()
         self.datatype = datatype
         self.typename = qualified_name(datatype, sep='::')
@@ -28,16 +28,8 @@ class CDR:
         self.nested = nested
         self.autoid_hash = autoid_hash
 
-        if keyless and keylist is not None:
-            raise TypeError("A keyless type cannot have a keylist")
-
-        if not keyless and keylist is None:
-            # Type is not keyless, but no keys were specified
-            # this means all fields are considered key
-            pass
-
         self.keylist = keylist
-        self.keyless = keyless
+        self.keyless = keylist is not None and len(keylist) == 0
 
         self.machine = None
         self.key_machine = None

--- a/src/pycdr/pycdr/main.py
+++ b/src/pycdr/pycdr/main.py
@@ -11,7 +11,6 @@
 """
 
 from hashlib import md5
-from dataclasses import fields
 
 from .support import Buffer, Endianness, qualified_name
 from .builder import Builder

--- a/src/pycdr/pycdr/main.py
+++ b/src/pycdr/pycdr/main.py
@@ -11,13 +11,15 @@
 """
 
 from hashlib import md5
+from dataclasses import fields
 
 from .support import Buffer, Endianness, qualified_name
 from .builder import Builder
 
 
 class CDR:
-    def __init__(self, datatype, final=True, mutable=False, appendable=False, nested=False, autoid_hash=False, keylist=None):
+    def __init__(self, datatype, final=True, mutable=False, appendable=False, nested=False, \
+                 autoid_hash=False, keylist=None, keyless=False):
         self.buffer = Buffer()
         self.datatype = datatype
         self.typename = qualified_name(datatype, sep='::')
@@ -26,8 +28,17 @@ class CDR:
         self.appendable = appendable
         self.nested = nested
         self.autoid_hash = autoid_hash
+
+        if keyless and keylist is not None:
+            raise TypeError("A keyless type cannot have a keylist")
+
+        if not keyless and keylist is None:
+            # Type is not keyless, but no keys were specified
+            # this means all fields are considered key
+            pass
+
         self.keylist = keylist
-        self.keyless = keylist is None
+        self.keyless = keyless
 
         self.machine = None
         self.key_machine = None

--- a/src/pycdr/tests/support_modules/test_classes.py
+++ b/src/pycdr/tests/support_modules/test_classes.py
@@ -72,6 +72,12 @@ class Keyed:
     b: int
 
 
+@cdr(keyless=True)
+class Keyless:
+    a: int
+    b: int
+
+
 @cdr
 class AllPrimitives:
     a: pt.int8 = 123

--- a/src/pycdr/tests/support_modules/test_classes.py
+++ b/src/pycdr/tests/support_modules/test_classes.py
@@ -72,7 +72,7 @@ class Keyed:
     b: int
 
 
-@cdr(keyless=True)
+@cdr(keylist=[])
 class Keyless:
     a: int
     b: int

--- a/src/pycdr/tests/test_basic_types.py
+++ b/src/pycdr/tests/test_basic_types.py
@@ -12,8 +12,7 @@ single_test_data = [
     (tc.SingleUint16, (0, 65535)),
     (tc.SingleBoundedSequence, ([], [1], [1,1], [100, 1, 1])),
     (tc.SingleBoundedString, ("123456789", "llsllë", "")),
-    (tc.SingleEnum, (tc.BasicEnum.One, tc.BasicEnum.Two, tc.BasicEnum.Three)),
-    (tc.SingleNested, (tc.SingleInt(1),))
+    (tc.SingleEnum, (tc.BasicEnum.One, tc.BasicEnum.Two, tc.BasicEnum.Three))
 ]
 
 
@@ -24,6 +23,7 @@ def test_simple_datatypes(_type, values):
         b = v1.serialize()
         v2 = _type.deserialize(b)
         assert v1 == v2
+        assert _type.cdr.keyhash(v1) == _type.cdr.keyhash(v2)
 
 
 def test_all_primitives():
@@ -31,6 +31,22 @@ def test_all_primitives():
     b = v1.serialize()
     v2 = tc.AllPrimitives.deserialize(b)
     assert v1 == v2
+
+
+def test_keyed():
+    v1 = tc.Keyed(a=1, b=2)
+    b = v1.serialize()
+    v2 = tc.Keyed.deserialize(b)
+    assert v1 == v2
+    assert tc.Keyed.cdr.keyhash(v1) == tc.Keyed.cdr.keyhash(v2)
+
+
+def test_keyless():
+    v1 = tc.Keyless(a=1, b=2)
+    b = v1.serialize()
+    v2 = tc.Keyless.deserialize(b)
+    assert v1 == v2
+    assert tc.Keyless.cdr.keyhash(v1) == tc.Keyless.cdr.keyhash(v2)
 
 
 def test_simple_union():

--- a/src/pycdr/tests/test_basic_types.py
+++ b/src/pycdr/tests/test_basic_types.py
@@ -12,7 +12,8 @@ single_test_data = [
     (tc.SingleUint16, (0, 65535)),
     (tc.SingleBoundedSequence, ([], [1], [1,1], [100, 1, 1])),
     (tc.SingleBoundedString, ("123456789", "llsllë", "")),
-    (tc.SingleEnum, (tc.BasicEnum.One, tc.BasicEnum.Two, tc.BasicEnum.Three))
+    (tc.SingleEnum, (tc.BasicEnum.One, tc.BasicEnum.Two, tc.BasicEnum.Three)),
+    (tc.SingleNested, (tc.SingleInt(1),))
 ]
 
 


### PR DESCRIPTION
This PR changes the semantics of `@cdr` to be as follows:
`@cdr` stands for "Keyed topic where all fields are key"
`@cdr(keyless=True)` stands for "Keyless topic, no fields are key"
`@cdr(keylist=[])` stands for "Keyed topic, no fields are key"

Since CI is not merged yet, here is a full run of tests:
https://dev.azure.com/tmiedema/cyclonedds-python/_build/results?buildId=165&view=results