### PR TITLE
Remove variable group Default reference.

### DIFF
--- a/.azure/publish-coverage.yml
+++ b/.azure/publish-coverage.yml
@@ -27,7 +27,6 @@ pool:
   vmImage: ubuntu-20.04
 
 variables:
-- group: Default
 - name: python-version
   value: 3.9
 

--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -19,9 +19,6 @@ trigger:
     include:
     - '*'
 
-variables:
-- group: Default
-
 jobs:
 - job: PublishPackage
   pool:


### PR DESCRIPTION
While my setup uses variable groups the CycloneDDS-Python Azure DevOps instance does not. This PR simply removes the variable group from the pipelines.