### PR TITLE
Fix Python Qos repr()

### DIFF
--- a/src/cyclonedds/cyclonedds/qos.py
+++ b/src/cyclonedds/cyclonedds/qos.py
@@ -693,7 +693,7 @@ class Qos:
         return True
 
     def __repr__(self):
-        return "Qos({})".format(", ".join(repr(p) for p in sorted(self.policies)))
+        return "Qos({})".format(", ".join(repr(p) for p in self.policies))
 
     __str__ = __repr__
 

--- a/src/cyclonedds/tests/test_qos.py
+++ b/src/cyclonedds/tests/test_qos.py
@@ -39,7 +39,10 @@ some_qosses = [
     Qos(Policy.IgnoreLocal.Process),
     Qos(Policy.Userdata(b"1298129891lsakdjflksadjflas")),
     Qos(Policy.Groupdata(b"\0ksdlfkjsldkfj")),
-    Qos(Policy.Topicdata(b"\n\nrrlskdjflsdj"))
+    Qos(Policy.Topicdata(b"\n\nrrlskdjflsdj")),
+    Qos(Policy.Userdata(b"1298129891lsakdjflksadjflas"),
+        Policy.Groupdata(b"\0ksdlfkjsldkfj"),
+        Policy.Topicdata(b"\n\nrrlskdjflsdj"))
 ]
 
 qos_pairs = list(itertools.combinations(some_qosses, 2))
@@ -52,25 +55,17 @@ def to_c_and_back(qos):
 
 
 @pytest.mark.parametrize("qos", some_qosses)
-def test_qos_conversion(qos):
+def test_qos_ops(qos):
     assert qos == to_c_and_back(qos)
-
-
-@pytest.mark.parametrize("qos", some_qosses)
-def test_qos_conversion(qos):
     assert qos == Qos.fromdict(qos.asdict())
+    for policy in qos:
+        assert policy in qos
+    repr(qos)
 
 
 @pytest.mark.parametrize("qos1,qos2", qos_pairs)
 def test_qos_inequality(qos1, qos2):
     assert qos1 != qos2
-
-
-@pytest.mark.parametrize("qos", some_qosses)
-def test_qos_loop(qos):
-    for policy in qos:
-        p = policy
-    assert p in qos
 
 
 def test_qos_lookup():
@@ -112,3 +107,4 @@ def test_qos_raise_wrong_usage():
 
     with pytest.raises(ValueError):
         Qos.fromdict({"Durability": {}})
+


### PR DESCRIPTION
This removes the sorting of policies in the `__repr__` of the python Qos object, since the policies are already sorted upon creation of the Qos object. This re-sorting didn't specify how to sort the objects and could fail, causing a crash. A test is also added to ensure the repr(qos) always works. Parametrized Qos tests are also combined for readability.