### PR TITLE
Change to user installs with pip in CI

### DIFF
--- a/.azure/publish-documentation.yml
+++ b/.azure/publish-documentation.yml
@@ -43,8 +43,8 @@ steps:
   - bash: |
       set -e -x
       cd docs
-      pip install --upgrade pip
-      pip install -r requirements.txt --user --upgrade
+      pip install --user --upgrade pip
+      pip install --user --upgrade -r requirements.txt
     name: install_sphinx
     displayName: Install Python dependencies
   - bash: |

--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -22,33 +22,42 @@ steps:
     name: install_python
     displayName: Install Python $(python-version)
   - bash: |
+      echo "###vso[task.setvariable variable=pip_cache;]$(pip cache dir)"
+    displayName: Obtain pip cache path
+  - task: Cache@2
+    inputs:
+      key: pip-test | 4 | $(Agent.OS)
+      path: $(pip_cache)
+    name: cache_pip
+    displayName: Retrieve pip cache
+  - bash: |
       set -e -x
-      pip install pip --upgrade
-      pip install pytest pytest-azurepipelines pytest-cov flake8
-      pip install ./src/pycdr
-      pip install ./src/cyclonedds
+      pip install --user --upgrade pip
+      pip install --user --upgrade pytest pytest-azurepipelines pytest-cov flake8
+      pip install --user ./src/pycdr
+      pip install --user ./src/cyclonedds
     name: install_cyclonedds_py
     displayName: Run installers
   - bash: |
-      flake8 ./src/pycdr/pycdr --count --select=E9,F63,F7,F82 --show-source --statistics
-      flake8 ./src/cyclonedds/cyclonedds --count --select=E9,F63,F7,F82 --show-source --statistics
-      flake8 ./src/pycdr/pycdr --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
-      flake8 ./src/cyclonedds/cyclonedds --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
+      python -m flake8 ./src/pycdr/pycdr --count --select=E9,F63,F7,F82 --show-source --statistics
+      python -m flake8 ./src/cyclonedds/cyclonedds --count --select=E9,F63,F7,F82 --show-source --statistics
+      python -m flake8 ./src/pycdr/pycdr --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
+      python -m flake8 ./src/cyclonedds/cyclonedds --count --exit-zero --max-complexity=10 --max-line-length=127 --per-file-ignores="__init__.py:F401" --statistics
     name: flake8_lint
     displayName: Run Flake8 Linter
   - bash: |
       cd ./src/pycdr
-      pytest --no-coverage-upload
+      python -m pytest --no-coverage-upload
     name: test_pycdr
     displayName: Run tests for PyCDR
   - bash: |
       cd ./src/cyclonedds
-      pytest --no-coverage-upload
+      python -m pytest --no-coverage-upload
     name: test_cyclonedds_py
     displayName: Run tests for CycloneDDS
   - bash: |
-      coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
-      coverage xml
+      python -m coverage combine src/cyclonedds/.coverage src/pycdr/.coverage
+      python -m coverage xml
     name: collect_test_coverage
     displayName: Collect PyCDR and CycloneDDS coverage data
   - task: PublishCodeCoverageResults@1

--- a/.azure/templates/publish-package.yml
+++ b/.azure/templates/publish-package.yml
@@ -22,7 +22,7 @@ steps:
     displayName: Fetch Python 3.9
   - bash: |
       set -e -x
-      pip install twine
+      pip install --user --upgrade twine
     name: install_twine
     displayName: Install Twine
   - bash: |

--- a/src/cyclonedds/tests/test_ddsls.py
+++ b/src/cyclonedds/tests/test_ddsls.py
@@ -18,7 +18,7 @@ from cyclonedds.core import Qos, Policy, WaitSet, ReadCondition, ViewState, Inst
 # Helper functions
 
 def run_ddsls(args, timeout=10):
-    ddsls_process = subprocess.Popen(["ddsls.py"] + args,
+    ddsls_process = subprocess.Popen(["python", "tools/ddsls.py"] + args,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      )
@@ -37,7 +37,7 @@ def run_ddsls(args, timeout=10):
 
 
 def start_ddsls_watchmode(args):
-    ddsls_process = subprocess.Popen(["ddsls.py", "--watch"] + args,
+    ddsls_process = subprocess.Popen(["python", "tools/ddsls.py", "--watch"] + args,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      )
@@ -472,15 +472,11 @@ def test_write_disposed_data_to_file(tmp_path):
         "dw.guid": str(dw.guid),
         "dr.guid": str(dr.guid)
     }
-    time.sleep(2)
-
-    waitset = WaitSet(dp)
-    cond = ReadCondition(dr, ViewState.Any | InstanceState.NotAliveDisposed | SampleState.Any)
-    waitset.attach(cond)
-
-    del dp
-    gc.collect()
     time.sleep(0.5)
+
+    del dp, tp, dw, dr
+    gc.collect()
+    time.sleep(1)
 
     stop_ddsls_watchmode(ddsls)
 

--- a/src/cyclonedds/tests/test_ddsls.py
+++ b/src/cyclonedds/tests/test_ddsls.py
@@ -1,4 +1,5 @@
 import pytest
+import platform
 import json
 import time
 import signal
@@ -37,15 +38,24 @@ def run_ddsls(args, timeout=10):
 
 
 def start_ddsls_watchmode(args):
-    ddsls_process = subprocess.Popen(["python", "tools/ddsls.py", "--watch"] + args,
+    if platform.system() == "Windows":
+        return subprocess.Popen(["python", "tools/ddsls.py", "--watch"] + args,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                startupinfo=subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        return subprocess.Popen(["python", "tools/ddsls.py", "--watch"] + args,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
-                                     )
-    return ddsls_process
+        )
 
 
 def stop_ddsls_watchmode(ddsls_process, timeout=10):
-    ddsls_process.send_signal(signal.SIGINT)
+    if platform.system() == "Windows":
+        os.kill(ddsls_process.pid, signal.CTRL_C_EVENT)
+    else:
+        ddsls_process.send_signal(signal.SIGINT)
 
     try:
         stdout, stderr = ddsls_process.communicate(timeout=timeout)


### PR DESCRIPTION
As demonstrated by [recent CI runs](https://dev.azure.com/eclipse-cyclonedds/cyclonedds-python/_build/results?buildId=593&view=logs&j=8e372324-b069-5441-ff7c-d552df30aa05&t=fd7072a0-3888-59bc-79c3-7952cda91f57) the default `pip install` path on windows is now a protected location. This commit changes all `pip install` invocations to use a `--user` flag. It also adds pip caching back in.
Because the `--user` install location is not on PATH on macOS by default this then breaks the mac build, so modules need to be invoked through Python instead of directly.