### PR TITLE
Keep objects alive

### DIFF
--- a/src/cyclonedds/cyclonedds/builtin.py
+++ b/src/cyclonedds/cyclonedds/builtin.py
@@ -13,12 +13,12 @@
 import uuid
 import ctypes as ct
 from dataclasses import dataclass
-from typing import Optional, Union, ClassVar, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 from .core import Entity, DDSException, Qos, ReadCondition, ViewState, InstanceState, SampleState
 from .topic import Topic
 from .sub import DataReader
-from .internal import c_call, dds_c_t, SampleInfo
+from .internal import dds_c_t
 from .qos import _CQos
 
 from ddspy import ddspy_read_participant, ddspy_take_participant, ddspy_read_endpoint, ddspy_take_endpoint
@@ -99,7 +99,8 @@ class BuiltinDataReader(DataReader):
         Parameters
         ----------
         subscriber_or_participant: cyclonedds.sub.Subscriber, cyclonedds.domain.DomainParticipant
-            The subscriber to which this reader will be added. If you supply a DomainParticipant a subscriber will be created for you.
+            The subscriber to which this reader will be added. If you supply a DomainParticipant
+            a subscriber will be created for you.
 
         builtin_topic: cyclonedds.builtin.BuiltinTopic
             Which Builtin Topic to subscribe to. This can be one of BuiltinTopicDcpsParticipant, BuiltinTopicDcpsTopic,
@@ -133,7 +134,8 @@ class BuiltinDataReader(DataReader):
             s.sample_info = sampleinfo
             return s
 
-        def endpoint_constructor(keybytes, participant_keybytes, p_instance_handle, topic_name, type_name, qosobject, sampleinfo):
+        def endpoint_constructor(keybytes, participant_keybytes, p_instance_handle, topic_name, type_name,
+                                 qosobject, sampleinfo):
             s = DcpsEndpoint(
                 uuid.UUID(bytes=keybytes),
                 uuid.UUID(bytes=participant_keybytes),
@@ -159,7 +161,8 @@ class BuiltinDataReader(DataReader):
             self._constructor = endpoint_constructor
         self._cqos_conv = cqos_to_qos
 
-    def read(self, N: int = 1, condition: Union['cyclonedds.core.ReadCondition', 'cyclonedds.core.QueryCondition']=None):
+    def read(self, N: int = 1,
+             condition: Union['cyclonedds.core.ReadCondition', 'cyclonedds.core.QueryCondition'] = None):
         """Read a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples
         you are interested in.
 
@@ -207,6 +210,7 @@ class BuiltinDataReader(DataReader):
             raise DDSException(ret, f"Occurred when calling read() in {repr(self)}")
 
         return ret
+
 
 _pseudo_handle = 0x7fff0000
 BuiltinTopicDcpsParticipant = BuiltinTopic(_pseudo_handle + 1, DcpsParticipant)

--- a/src/cyclonedds/cyclonedds/builtin.py
+++ b/src/cyclonedds/cyclonedds/builtin.py
@@ -127,6 +127,7 @@ class BuiltinDataReader(DataReader):
         if cqos:
             _CQos.cqos_destroy(cqos)
         self._make_constructors()
+        self._keepalive_entities = [self.subscriber]
 
     def _make_constructors(self):
         def participant_constructor(keybytes, qosobject, sampleinfo):

--- a/src/cyclonedds/cyclonedds/pub.py
+++ b/src/cyclonedds/cyclonedds/pub.py
@@ -43,6 +43,7 @@ class Publisher(Entity):
         )
         if cqos:
             _CQos.cqos_destroy(cqos)
+        self._keepalive_entities = [self.participant]
 
     def suspend(self):
         ret = self._suspend(self._ref)
@@ -94,8 +95,16 @@ class DataWriter(Entity):
             ),
             listener=listener
         )
+
+        self._topic_ref = topic._ref
         if cqos:
             _CQos.cqos_destroy(cqos)
+
+        self._keepalive_entities = [self.publisher, self.topic]
+
+    @property
+    def topic(self) -> 'cyclonedds.topic.Topic':
+        return self.get_entity(self._topic_ref)
 
     def write(self, sample, timestamp=None):
         if timestamp is not None:

--- a/src/cyclonedds/cyclonedds/qos.py
+++ b/src/cyclonedds/cyclonedds/qos.py
@@ -360,7 +360,8 @@ class Policy:
             # Tuple-fy partitions to ensure immutability
             # The super trick here is because the class is already frozen so _officially_
             # we are not supposed to be able to edit this variable.
-            super().__setattr__('partitions', tuple(getattr(self, 'partitions')))
+            partitions = [self.partitions] if type(self.partitions) == str else self.partitions
+            super().__setattr__('partitions', tuple(partitions))
 
     @dataclass(frozen=True)
     class TransportPriority(BasePolicy):
@@ -531,7 +532,8 @@ class Qos:
             Check if a Policy p is contained in Qos object qos. You can use all levels of generalization, for example:
             ``Policy.History in qos``, ``Policy.History.KeepLast in qos`` and ``Policy.History.KeepLast(1) in qos``.
         .. describe:: qos[p]
-            Obtain the Policy matched with p from the Qos object, for example: ``qos[Policy.History] -> Policy.History.KeepAll``
+            Obtain the Policy matched with p from the Qos object, for example:
+            ``qos[Policy.History] -> Policy.History.KeepAll``
         .. describe:: iter(x)
             The Qos object supports iteration over it's contents.
         .. describe:: len(x)
@@ -700,7 +702,7 @@ class Qos:
         for p in self.policies:
             path = p.__class__.__qualname__.split(".")
             data = asdict(p)
-            for k,v in data.items():
+            for k, v in data.items():
                 if type(v) == bytes:
                     data[k] = b64encode(v).decode()
             if len(path) == 2:

--- a/src/cyclonedds/cyclonedds/sub.py
+++ b/src/cyclonedds/cyclonedds/sub.py
@@ -43,6 +43,7 @@ class Subscriber(Entity):
         )
         if cqos:
             _CQos.cqos_destroy(cqos)
+        self._keepalive_entities = [self.participant]
 
     def notify_readers(self):
         ret = self._notify_readers(self._ref)
@@ -99,6 +100,11 @@ class DataReader(Entity):
         self._next_condition = None
         if cqos:
             _CQos.cqos_destroy(cqos)
+        self._keepalive_entities = [self.subscriber, topic]
+
+    @property
+    def topic(self) -> 'cyclonedds.topic.Topic':
+        return self._topic
 
     def read(self, N: int = 1, condition: Entity = None, instance_handle: int = None) -> List[object]:
         """Read a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples

--- a/src/cyclonedds/cyclonedds/sub.py
+++ b/src/cyclonedds/cyclonedds/sub.py
@@ -74,7 +74,8 @@ class DataReader(Entity):
         Parameters
         ----------
         subscriber_or_participant: cyclonedds.sub.Subscriber, cyclonedds.domain.DomainParticipant
-            The subscriber to which this reader will be added. If you supply a DomainParticipant a subscriber will be created for you.
+            The subscriber to which this reader will be added. If you supply a DomainParticipant a subscriber
+            will be created for you.
         builtin_topic: cyclonedds.builtin.BuiltinTopic
             Which Builtin Topic to subscribe to. This can be one of BuiltinTopicDcpsParticipant, BuiltinTopicDcpsTopic,
             BuiltinTopicDcpsPublication or BuiltinTopicDcpsSubscription. Please note that BuiltinTopicDcpsTopic will fail if

--- a/src/cyclonedds/cyclonedds/topic.py
+++ b/src/cyclonedds/cyclonedds/topic.py
@@ -48,6 +48,7 @@ class Topic(Entity):
         )
         if cqos:
             _CQos.cqos_destroy(cqos)
+        self._keepalive_entities = [self.participant]
 
     def get_name(self, max_size=256):
         name = (ct.c_char * max_size)()

--- a/src/cyclonedds/tests/test_reader.py
+++ b/src/cyclonedds/tests/test_reader.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cyclonedds.domain import DomainParticipant
+from cyclonedds.domain import Domain, DomainParticipant
 from cyclonedds.topic import Topic
 from cyclonedds.sub import Subscriber, DataReader
 from cyclonedds.pub import Publisher, DataWriter
@@ -130,3 +130,17 @@ def test_reader_takeiter():
         assert not read
         assert msg == msgr
         read = True
+
+
+def _make_reader_without_saving_deps():
+    tp = Topic(DomainParticipant(0), "Message", Message)
+    return DataReader(Subscriber(tp.participant), tp)
+
+
+def test_reader_keepalive_parents():
+    dr = _make_reader_without_saving_deps()
+
+    msg = Message("Hello")
+    dw = DataWriter(dr.participant, dr.topic).write(msg)
+
+    assert dr.read_next() == msg

--- a/src/pycdr/pycdr/machinery.py
+++ b/src/pycdr/pycdr/machinery.py
@@ -370,7 +370,7 @@ class MappingMachine(Machine):
         buffer.align(2)
         num = buffer.read('H', 2)
 
-        for i in range(num):
+        for _i in range(num):
             key = self.key_machine.deserialize(buffer)
             value = self.value_machine.deserialize(buffer)
             ret[key] = value
@@ -414,7 +414,7 @@ class StructMachine(Machine):
         return self.type(**valuedict)
 
     def max_size(self, finder):
-        for k, m in self.members_machines.items():
+        for m in self.members_machines.values():
             m.max_size(finder)
 
     def cdr_key_machine_op(self, skip):
@@ -463,7 +463,7 @@ class EnumMachine(Machine):
         self.enum = enum
 
     def serialize(self, buffer, value):
-        buffer.write("I", 4, int(value))
+        buffer.write("I", 4, value.value)
 
     def deserialize(self, buffer):
         return self.enum(buffer.read("I", 4))

--- a/src/pycdr/pycdr/main.py
+++ b/src/pycdr/pycdr/main.py
@@ -17,7 +17,7 @@ from .builder import Builder
 
 
 class CDR:
-    def __init__(self, datatype, final=True, mutable=False, appendable=False, nested=False, \
+    def __init__(self, datatype, final=True, mutable=False, appendable=False, nested=False,
                  autoid_hash=False, keylist=None):
         self.buffer = Buffer()
         self.datatype = datatype


### PR DESCRIPTION
This make sure that DataReaders keep a ref to their Subscriber and Subscribers keep a ref to their Participant etc. I also took the opportunity to clear out some unused imports and other minor style inconsistencies as reported by flake8.