### PR TITLE
Some compiler fixes and switch to scikit-build

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -38,6 +38,8 @@ steps:
       pip install --user ./src/cyclonedds
     name: install_cyclonedds_py
     displayName: Run installers
+    env:
+      cflags: -Werror
   - bash: |
       python -m flake8 ./src/pycdr/pycdr --count --select=E9,F63,F7,F82 --show-source --statistics
       python -m flake8 ./src/cyclonedds/cyclonedds --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@
 trigger: [ '*' ]
 pr: [ '*' ]
 
+variables:
+  build_type: RelWithDebugInfo
 
 jobs:
 - job: BuildCyclone
@@ -62,15 +64,11 @@ jobs:
         python-version: 3.9
         build_type: Debug
   steps:
-  - bash: |
-      [[ -n "${BUILD_TYPE}" ]] || \
-        echo "###vso[task.setvariable variable=build_type;]RelWithDebugInfo"
-    name: build_type_setter
-    displayName: Check the build type.
   - download: current
     artifact: cyclone-$(Agent.OS)-$(build_type)
   - bash: |
       echo "###vso[task.setvariable variable=cyclonedds_home;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)-$(build_type)"
+      echo "###vso[task.setvariable variable=CMAKE_PREFIX_PATH;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)-$(build_type)"
     name: set_cyclonedds_home
     displayName: Set CYCLONEDDS_HOME
   - template: /.azure/templates/build-test.yml

--- a/src/cyclonedds/CMakeLists.txt
+++ b/src/cyclonedds/CMakeLists.txt
@@ -4,6 +4,18 @@ project(_clayer LANGUAGES C)
 find_package(PythonExtensions REQUIRED)
 find_package(CycloneDDS REQUIRED)
 
+# Set reasonably strict warning options for Clang, GCC and Visual Studio
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR
+   CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+  add_compile_options(-Wall -Wextra -Wconversion -Wmissing-prototypes -Wunused
+                      -Winfinite-recursion -Wassign-enum -Wcomma -Wshadow
+                      -Wstrict-prototypes -Wconditional-uninitialized)
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  add_compile_options(-Wall -Wextra -Wconversion -Wmissing-prototypes)
+elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  add_compile_options(/W3)
+endif()
+
 add_library(_clayer MODULE clayer/src/cdrkeyvm.c clayer/src/pysertype.c)
 target_link_libraries(_clayer CycloneDDS::ddsc)
 python_extension_module(_clayer)

--- a/src/cyclonedds/CMakeLists.txt
+++ b/src/cyclonedds/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.18)
+# CMAKE_PREFIX_PATH environment variable is available in CMake >= 3.18
+project(_clayer LANGUAGES C)
+find_package(PythonExtensions REQUIRED)
+find_package(CycloneDDS REQUIRED)
+
+add_library(_clayer MODULE clayer/src/cdrkeyvm.c clayer/src/pysertype.c)
+target_link_libraries(_clayer CycloneDDS::ddsc)
+python_extension_module(_clayer)
+install(
+  TARGETS _clayer
+  LIBRARY DESTINATION cyclonedds
+  RUNTIME DESTINATION cyclonedds)

--- a/src/cyclonedds/clayer/src/cdrkeyvm.c
+++ b/src/cyclonedds/clayer/src/cdrkeyvm.c
@@ -17,13 +17,9 @@
 #include <assert.h>
 #include <inttypes.h>
 
-#define ALIGN(X, VAL) X = ((X + VAL - 1) & ~(VAL - 1))
-
-
-bool endianness_is_little() {
-    volatile uint32_t i=0x01234567;
-    // return 0 for big endian, 1 for little endian.
-    return (*((uint8_t*)(&i))) == 0x67;
+static inline size_t ALIGN(size_t x, size_t val)
+{
+  return ((x + (val - 1)) & !(val - 1));
 }
 
 cdr_key_vm_runner* cdr_key_vm_create_runner(cdr_key_vm* vm)
@@ -71,7 +67,6 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
 
     // Work relative from post-dds-header
     const uint8_t* cdr_sample = cdr_sample_in + 4;
-    const size_t cdr_sample_size = cdr_sample_size_in - 4;
 
     memset(runner->workspace, 0, runner->workspace_size);
 

--- a/src/cyclonedds/clayer/src/cdrkeyvm.c
+++ b/src/cyclonedds/clayer/src/cdrkeyvm.c
@@ -39,7 +39,7 @@ cdr_key_vm_runner* cdr_key_vm_create_runner(cdr_key_vm* vm)
     return runner;
 }
 
-void make_space_for(cdr_key_vm_runner* runner, size_t size) {
+static void make_space_for(cdr_key_vm_runner* runner, size_t size) {
     // If you misconfigure things the following will wreak havoc
     if (runner->my_vm->final_size_is_static) return;
 
@@ -67,6 +67,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
 
     // Work relative from post-dds-header
     const uint8_t* cdr_sample = cdr_sample_in + 4;
+    (void)cdr_sample_size_in;
 
     memset(runner->workspace, 0, runner->workspace_size);
 
@@ -187,14 +188,14 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                     switch(instruction->align) {
                         default: assert(0); break;
                         case 2:
-                            for (int i = size; i > 0; i -= 2) {
+                            for (size_t i = size; i > 0; i -= 2) {
                                 uint8_t tmp = *(runner->workspace + workspace_pos - i);
                                 *(runner->workspace + workspace_pos - i) = *(runner->workspace + workspace_pos - i + 1);
                                 *(runner->workspace + workspace_pos - i + 1) = tmp;
                             }
                         break;
                         case 4:
-                            for (int i = size; i > 0; i -= 4) {
+                            for (size_t i = size; i > 0; i -= 4) {
                                 uint8_t tmp = *(runner->workspace + workspace_pos - i);
                                 *(runner->workspace + workspace_pos - i) = *(runner->workspace + workspace_pos - i + 3);
                                 *(runner->workspace + workspace_pos - i + 3) = tmp;
@@ -204,7 +205,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                             }
                         break;
                         case 8:
-                            for (int i = size; i > 0; i -= 8) {
+                            for (size_t i = size; i > 0; i -= 8) {
                                 uint8_t tmp = *(runner->workspace + workspace_pos - i);
                                 *(runner->workspace + workspace_pos - i) = *(runner->workspace + workspace_pos - i + 7);
                                 *(runner->workspace + workspace_pos - i + 7) = tmp;

--- a/src/cyclonedds/clayer/src/cdrkeyvm.h
+++ b/src/cyclonedds/clayer/src/cdrkeyvm.h
@@ -54,5 +54,4 @@ cdr_key_vm_runner;
 cdr_key_vm_runner* cdr_key_vm_create_runner(cdr_key_vm* vm);
 size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample, const size_t cdr_sample_size);
 
-
 #endif // CDR_KEY_VM_H

--- a/src/cyclonedds/clayer/src/pysertype.c
+++ b/src/cyclonedds/clayer/src/pysertype.c
@@ -208,10 +208,11 @@ void ddspy_serdata_populate_key(ddspy_serdata_t* this)
 
 bool serdata_eqkey(const struct ddsi_serdata* a, const struct ddsi_serdata* b)
 {
-    if (csertype(a)->keyless ^ csertype(b)->keyless) {
+    const ddspy_serdata_t *apy = cserdata(a), *bpy = cserdata(b);
+    if (csertype(apy)->keyless ^ csertype(bpy)->keyless) {
         return false;
     }
-    if (csertype(a)->keyless & csertype(b)->keyless) {
+    if (csertype(apy)->keyless & csertype(bpy)->keyless) {
         return true;
     }
 
@@ -493,7 +494,7 @@ void serdata_get_keyhash(const ddsi_serdata_t* d, struct ddsi_keyhash* buf, bool
     assert(cserdata(d)->key_size >= 16);
     assert(d->type != NULL);
 
-    if (csertype(d)->keyless) {
+    if (csertype(cserdata(d))->keyless) {
         memset(buf->value, 0, 16);
     }
 

--- a/src/cyclonedds/clayer/src/pysertype.h
+++ b/src/cyclonedds/clayer/src/pysertype.h
@@ -1,0 +1,9 @@
+#ifndef PYSERTYPE_H
+#define PYSERTYPE_H
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+PyMODINIT_FUNC PyInit__clayer(void);
+
+#endif // PYSERTYPE_H

--- a/src/cyclonedds/pyproject.toml
+++ b/src/cyclonedds/pyproject.toml
@@ -4,7 +4,10 @@ requires-python = ">=3.6"
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "scikit-build",
+    "cmake>=3.18.0",
+    "ninja"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/cyclonedds/setup.py
+++ b/src/cyclonedds/setup.py
@@ -13,24 +13,8 @@
 
 import os
 import logging
-from setuptools import setup, find_packages, Extension
-
-
-if "CYCLONEDDS_HOME" in os.environ:
-    home = os.environ["CYCLONEDDS_HOME"]
-    ddspy = Extension('cyclonedds._clayer',
-        sources = ['clayer/src/pysertype.c', 'clayer/src/cdrkeyvm.c'],
-        libraries=['ddsc'],
-        include_dirs=[os.path.join(home, "include"), os.path.join('clayer', 'src')],
-        library_dirs=[os.path.join(home, "lib"), os.path.join(home, "lib64"), os.path.join(home, "bin")]
-    )
-else:
-    logging.warning("No CYCLONEDDS_HOME set, trying to build with CycloneDDS on loadable path.")
-    ddspy = Extension('cyclonedds._clayer',
-        sources = ['clayer/src/pysertype.c', 'clayer/src/cdrkeyvm.c'],
-        libraries=['ddsc'],
-        include_dirs=['clayer/src']
-    )
+from setuptools import find_packages
+from skbuild import setup
 
 setup(
     name='cyclonedds',
@@ -53,8 +37,7 @@ setup(
         "Operating System :: OS Independent"
     ],
     install_requires=["pycdr"],
-    packages=find_packages(exclude=("tests", "examples")),
-	ext_modules = [ddspy],
+    packages=find_packages('.', exclude=("tests", "examples")),
     scripts=['tools/ddsls.py'],
     python_requires='>=3.6'
 )


### PR DESCRIPTION
Was trying something and wanted to compile against build install. Thought the scikit-build was a nice addition as it allows for better integration with CMake, which is used for Cyclone DDS. i.e. when users use the Windows installer it'll find everything without having to set `CYCLONEDDS_HOME`. I'll have to see how to find the proper path for runtime too, so it's a draft. We probably want to have a look at the fact `ddspy` is now a module as opposed to an extension.