### PR TITLE
CDR Key Vm Alignment test&fix

### DIFF
--- a/src/cyclonedds/clayer/src/cdrkeyvm.c
+++ b/src/cyclonedds/clayer/src/cdrkeyvm.c
@@ -19,7 +19,7 @@
 
 static inline size_t ALIGN(size_t x, size_t val)
 {
-  return ((x + (val - 1)) & !(val - 1));
+  return ((x + (val - 1)) & ~(val - 1));
 }
 
 cdr_key_vm_runner* cdr_key_vm_create_runner(cdr_key_vm* vm)
@@ -81,7 +81,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
             break;
 
             case CdrKeyVMOpStreamStatic:
-                ALIGN(sample_pos, instruction->align);
+                sample_pos = ALIGN(sample_pos, instruction->align);
 
                 if (instruction->skip) {
                     copy = false;
@@ -91,7 +91,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 }
                 else {
                     copy = true;
-                    ALIGN(workspace_pos, instruction->align);
+                    workspace_pos = ALIGN(workspace_pos, instruction->align);
                     size = instruction->size;
                     make_space_for(runner, workspace_pos + size);
                 }
@@ -99,7 +99,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
             break;
 
             case CdrKeyVMOpStream2ByteSize:
-                ALIGN(sample_pos, 2);
+                sample_pos = ALIGN(sample_pos, 2);
 
                 if (instruction->skip) {
                     copy = false;
@@ -108,7 +108,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                         ((size_t)*(cdr_sample + sample_pos) << 8) | ((size_t)*(cdr_sample + sample_pos + 1));
                     sample_pos += 2;
                     if (size > 0) {
-                        ALIGN(sample_pos, instruction->align);
+                        sample_pos = ALIGN(sample_pos, instruction->align);
                         size *= instruction->size;
                         sample_pos += size;
                     } else {
@@ -117,7 +117,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 }
                 else {
                     copy = true;
-                    ALIGN(workspace_pos, 2);
+                    workspace_pos = ALIGN(workspace_pos, 2);
                     size = stream_little_endian ? 
                         ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) :
                         ((size_t)*(cdr_sample + sample_pos) << 8) | ((size_t)*(cdr_sample + sample_pos + 1));
@@ -128,8 +128,8 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                     sample_pos += 2;
                     size *= instruction->size;
                     if (size > 0) {
-                        ALIGN(sample_pos, instruction->align);
-                        ALIGN(workspace_pos, instruction->align);
+                        sample_pos = ALIGN(sample_pos, instruction->align);
+                        workspace_pos = ALIGN(workspace_pos, instruction->align);
                         make_space_for(runner, workspace_pos + size);
                     } else {
                         copy = false;
@@ -139,7 +139,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
             break;
 
             case CdrKeyVMOpStream4ByteSize:
-                ALIGN(sample_pos, 4);
+                sample_pos = ALIGN(sample_pos, 4);
 
                 if (instruction->skip) {
                     copy = false;
@@ -149,14 +149,14 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                         ((size_t)*(cdr_sample + sample_pos + 3)) | ((size_t)*(cdr_sample + sample_pos + 2) << 8) | 
                         ((size_t)*(cdr_sample + sample_pos + 1) << 16) | ((size_t)*(cdr_sample + sample_pos) << 24);
                     sample_pos += 4;
-                    ALIGN(sample_pos, instruction->align);
+                    sample_pos = ALIGN(sample_pos, instruction->align);
                     size *= instruction->size;
                     sample_pos += size;
                 }
                 else {
                     copy = true;
-                    ALIGN(sample_pos, 4);
-                    ALIGN(workspace_pos, 4);
+                    sample_pos = ALIGN(sample_pos, 4);
+                    workspace_pos = ALIGN(workspace_pos, 4);
                     size = stream_little_endian ? 
                         ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) | 
                         ((size_t)*(cdr_sample + sample_pos + 2) << 16) | ((size_t)*(cdr_sample + sample_pos + 3) << 24) :
@@ -172,8 +172,8 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                     size *= instruction->size;
                     
                     if (size > 0) {
-                        ALIGN(sample_pos, instruction->align);
-                        ALIGN(workspace_pos, instruction->align);
+                        sample_pos = ALIGN(sample_pos, instruction->align);
+                        workspace_pos = ALIGN(workspace_pos, instruction->align);
                         make_space_for(runner, workspace_pos + size);
                     } else {
                         copy = false;
@@ -241,7 +241,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                     // Stack overflow!
                     assert(0);
                 }
-                ALIGN(sample_pos, 2);
+                sample_pos = ALIGN(sample_pos, 2);
                 size = stream_little_endian ? 
                     ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) :
                     ((size_t)*(cdr_sample + sample_pos) << 8) | ((size_t)*(cdr_sample + sample_pos + 1));
@@ -249,7 +249,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 sample_pos += 2;
                 
                 if (!instruction->skip) {
-                    ALIGN(workspace_pos, 2);
+                    workspace_pos = ALIGN(workspace_pos, 2);
                     make_space_for(runner, workspace_pos + 2);
                     *(runner->workspace + workspace_pos++) = (uint8_t) ((size >> 8) & 0xFF);
                     *(runner->workspace + workspace_pos++) = (uint8_t) (size & 0xFF);
@@ -270,7 +270,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                     // Stack overflow!
                     assert(0);
                 }
-                ALIGN(sample_pos, 4);
+                sample_pos = ALIGN(sample_pos, 4);
                 size = stream_little_endian ? 
                     ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) | 
                     ((size_t)*(cdr_sample + sample_pos + 2) << 16) | ((size_t)*(cdr_sample + sample_pos + 3) << 24) :
@@ -280,7 +280,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 sample_pos += 4;
 
                 if (!instruction->skip) {
-                    ALIGN(workspace_pos, 4);
+                    workspace_pos = ALIGN(workspace_pos, 4);
                     make_space_for(runner, workspace_pos + 4);
                     *(runner->workspace + workspace_pos++) = (uint8_t) ((size >> 24) & 0xFF);
                     *(runner->workspace + workspace_pos++) = (uint8_t) ((size >> 16) & 0xFF);
@@ -327,14 +327,14 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
 
             case CdrKeyVMOpUnion2Byte:
                 copy = false;
-                ALIGN(sample_pos, 2);
+                sample_pos = ALIGN(sample_pos, 2);
                 value = stream_little_endian ? 
                     ((uint64_t)*(cdr_sample + sample_pos)) | ((uint64_t)*(cdr_sample + sample_pos + 1) << 8) :
                     ((uint64_t)*(cdr_sample + sample_pos) << 8) | ((uint64_t)*(cdr_sample + sample_pos + 1));
 
                 if (instruction->value == value) {
                     if (!instruction->skip) {
-                        ALIGN(workspace_pos, 2);
+                        workspace_pos = ALIGN(workspace_pos, 2);
                         make_space_for(runner, workspace_pos + 2);
                         *(runner->workspace + workspace_pos++) = (uint8_t) ((value >> 8) & 0xFF);
                         *(runner->workspace + workspace_pos++) = (uint8_t) (value & 0xFF);
@@ -349,7 +349,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
 
             case CdrKeyVMOpUnion4Byte:
                 copy = false;
-                ALIGN(sample_pos, 4);
+                sample_pos = ALIGN(sample_pos, 4);
                 value = stream_little_endian ? 
                     ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) | 
                     ((size_t)*(cdr_sample + sample_pos + 2) << 16) | ((size_t)*(cdr_sample + sample_pos + 3) << 24) :
@@ -358,7 +358,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 
                 if (instruction->value == value) {
                     if (!instruction->skip) {
-                        ALIGN(workspace_pos, 4);
+                        workspace_pos = ALIGN(workspace_pos, 4);
                         make_space_for(runner, workspace_pos + 4);
                         *(runner->workspace + workspace_pos++) = (uint8_t) ((value >> 24) & 0xFF);
                         *(runner->workspace + workspace_pos++) = (uint8_t) ((value >> 16) & 0xFF);
@@ -375,7 +375,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
 
             case CdrKeyVMOpUnion8Byte:
                 copy = false;
-                ALIGN(sample_pos, 8);
+                sample_pos = ALIGN(sample_pos, 8);
                 value = stream_little_endian ? 
                     ((size_t)*(cdr_sample + sample_pos)) | ((size_t)*(cdr_sample + sample_pos + 1) << 8) | 
                     ((size_t)*(cdr_sample + sample_pos + 2) << 16) | ((size_t)*(cdr_sample + sample_pos + 3) << 24) |
@@ -388,7 +388,7 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
                 
                 if (instruction->value == value) {
                     if (!instruction->skip) {
-                        ALIGN(workspace_pos, 8);
+                        workspace_pos = ALIGN(workspace_pos, 8);
                         make_space_for(runner, workspace_pos + 8);
                         *(runner->workspace + workspace_pos++) = (uint8_t) ((value >> 56) & 0xFF);
                         *(runner->workspace + workspace_pos++) = (uint8_t) ((value >> 48) & 0xFF);

--- a/src/cyclonedds/tests/support_modules/testtopics/__init__.py
+++ b/src/cyclonedds/tests/support_modules/testtopics/__init__.py
@@ -1,1 +1,1 @@
-from .message import Message, MessageAlt, MessageKeyed
+from .message import Message, MessageAlt, MessageKeyed, KeyedArrayType

--- a/src/cyclonedds/tests/support_modules/testtopics/message.py
+++ b/src/cyclonedds/tests/support_modules/testtopics/message.py
@@ -1,4 +1,5 @@
 from pycdr import cdr
+from pycdr.types import array, int16, int32, int64
 
 
 @cdr
@@ -16,3 +17,13 @@ class MessageAlt:
 class MessageKeyed:
     user_id: int
     message: str
+
+
+@cdr(keylist=["arr1a", "arr2a", "arr3a", "arr4a"])
+class KeyedArrayType:
+    arr1a: array[str, 3]
+    arr1b: array[str, 3]
+    arr2a: array[int64, 3]
+    arr2b: array[int16, 3]
+    arr3a: array[int32, 3]
+    arr3b: array[int64, 3]

--- a/src/cyclonedds/tests/test_keyed_type.py
+++ b/src/cyclonedds/tests/test_keyed_type.py
@@ -1,0 +1,28 @@
+import pytest
+
+from cyclonedds.domain import DomainParticipant
+from cyclonedds.topic import Topic
+from cyclonedds.sub import DataReader
+from cyclonedds.pub import DataWriter
+
+from testtopics import KeyedArrayType
+
+
+def test_keyed_type_alignment():
+    dp = DomainParticipant()
+    tp = Topic(dp, "Test", KeyedArrayType)
+    dw = DataWriter(dp, tp)
+    dr = DataReader(dp, tp)
+
+    samp1 = KeyedArrayType(
+        ['u' * 17, 's' * 13, 'b' * 23],
+        ['u' * 3, 's' * 5, 'b' * 7],
+        [-1] * 3,
+        [-1] * 3,
+        [-1] * 3,
+        [-1] * 3
+    )
+
+    dw.write(samp1)
+    samp2 = dr.read()[0]
+    assert KeyedArrayType.cdr.key(samp1) == KeyedArrayType.cdr.key(samp2)


### PR DESCRIPTION
Simple testcase that verifies alignment works correctly. This will segfault while the [cdr keyvm fix](https://github.com/YixianLv/cyclonedds-python/commit/c4e791afba245d9f2e515e0f0bd2058b4b7fe923) is not in.