### PR TITLE
Relax test on status changes

### DIFF
--- a/src/cyclonedds/tests/test_communication.py
+++ b/src/cyclonedds/tests/test_communication.py
@@ -66,7 +66,7 @@ def test_communication_status_mask(common_setup):
     del common_setup.dw
 
     status = common_setup.dr.get_status_changes()
-    assert status == DDSStatus.PublicationMatched
+    assert (status & DDSStatus.PublicationMatched) != 0
 
     status = common_setup.dr.take_status()
-    assert status == DDSStatus.PublicationMatched
+    assert (status & DDSStatus.PublicationMatched) != 0


### PR DESCRIPTION
Needed because of status mask behaviour fix
https://github.com/eclipse-cyclonedds/cyclonedds/commit/a3ac2fd83c2a087cd01d2118b7ff8070fe4b8984

Signed-off-by: Erik Boasson <eb@ilities.com>