### PR TITLE
Topic generic typing

### DIFF
--- a/cyclonedds/__init__.py
+++ b/cyclonedds/__init__.py
@@ -9,3 +9,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 """
+
+from . import internal, util, qos, core, domain, topic, pub, sub, builtin, dynamic, idl
+
+__all__ = [
+    "internal",
+    "util",
+    "qos",
+    "core",
+    "domain",
+    "topic",
+    "pub",
+    "sub",
+    "builtin",
+    "dynamic",
+    "idl",
+]

--- a/cyclonedds/idl/_type_helper.py
+++ b/cyclonedds/idl/_type_helper.py
@@ -16,12 +16,11 @@ import sys
 if sys.version_info < (3, 7):
     raise NotImplementedError("This package cannot be used in Python version 3.6 or lower.")
 elif sys.version_info < (3, 9):
-    # We are in any Python 3.7 or 3.8 version
+    # We are in any Python 3.7/3.8
     from typing_extensions import Annotated, get_origin, get_args, get_type_hints  # noqa F401
-    from typing import ForwardRef
 else:
     # We are in any Python 3.9 or 3.10 (maybe higher?) version
-    from typing import Annotated, get_origin, get_args, get_type_hints, ForwardRef  # noqa F401
+    from typing import Annotated, get_origin, get_args, get_type_hints  # noqa F401
 
 
-__all__ = ["Annotated", "get_origin", "get_args", "get_type_hints", "ForwardRef"]
+__all__ = ["Annotated", "get_origin", "get_args", "get_type_hints"]

--- a/cyclonedds/idl/_type_normalize.py
+++ b/cyclonedds/idl/_type_normalize.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, Union, Optional
+from typing import Any, Dict, Union, ForwardRef
 from importlib import import_module
 
-from ._type_helper import Annotated, ForwardRef, get_origin, get_args
+from ._type_helper import Annotated, get_origin, get_args
 from .types import array, sequence, typedef, case, default, NoneType
 
 

--- a/cyclonedds/topic.py
+++ b/cyclonedds/topic.py
@@ -11,11 +11,12 @@
 """
 
 import ctypes as ct
-from typing import Any, AnyStr, Optional, TYPE_CHECKING
+from typing import Union, AnyStr, Optional, Generic, Type, TypeVar, TYPE_CHECKING
 
 from .internal import c_call, dds_c_t
 from .core import Entity, DDSException, Listener
 from .qos import _CQos, Qos, LimitedScopeQos, TopicQos
+from .idl import IdlStruct, IdlUnion
 
 from cyclonedds._clayer import ddspy_topic_create
 
@@ -24,14 +25,16 @@ if TYPE_CHECKING:
     import cyclonedds
 
 
-class Topic(Entity):
+_S = TypeVar("_S", bound=Union[IdlStruct, IdlUnion])
+
+class Topic(Entity, Generic[_S]):
     """Representing a Topic"""
 
     def __init__(
             self,
             domain_participant: 'cyclonedds.domain.DomainParticipant',
             topic_name: AnyStr,
-            data_type: Any,
+            data_type: Type[_S],
             qos: Optional[Qos] = None,
             listener: Optional[Listener] = None):
         if qos is not None:


### PR DESCRIPTION
This pull request doesn't introduce any new functionality, it just sorts out the type hints for topics, datareaders and datawriters so that the .read* en .write* methods will give correct type information to static type checkers, making them much more pleasant to use in an IDE. Consider the following:

```python
from cyclonedds import domain, topic, sub
from cyclonedds.idl import IdlStruct

class A(IdlStruct):
    f1: int
    f2: float

dp = domain.DomainParticipant()
tp = topic.Topic(dp, "bla", A)
dr = sub.DataReader(dp, tp)
a = dr.read()[0]
print(a.|
```
I have introduced a mock cursor. Previously IDE's would not be aware that typeof(a) == A so you would not get the autocomplete options "f1" or "f2". This pull request fixes this.