### PR TITLE
Some minor fixes on idlpy

### DIFF
--- a/idlpy/CMakeLists.txt
+++ b/idlpy/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(idlpy PUBLIC CycloneDDS::idl)
 install(
   TARGETS idlpy
   LIBRARY DESTINATION cyclonedds/.libs
+  RUNTIME DESTINATION cyclonedds/.libs
 )
 
 if (DEFINED CIBUILDWHEEL AND "${CIBUILDWHEEL}")


### PR DESCRIPTION
On windows the lib was not installed to the correct folder, since a 'dll' qualifies as a runtime artifact not a library like a '.so'. Not that the windows lib works now, the segfault due to free'ing memory from another library (thus the need for idl_free) is still present.

Also fixed a minor issue where the interaction between 'py-root-prefix' and types in the top level would result in a faulty import.