### PR TITLE
Fix several issues with untyped serdatas

### DIFF
--- a/clayer/cdrkeyvm.c
+++ b/clayer/cdrkeyvm.c
@@ -635,6 +635,5 @@ size_t cdr_key_vm_run(cdr_key_vm_runner* runner, const uint8_t* cdr_sample_in, c
         }
     }
 
-    workspace_pos = ALIGN(workspace_pos, 4);
     return workspace_pos + 4;
 }

--- a/cyclonedds/idl/_support.py
+++ b/cyclonedds/idl/_support.py
@@ -144,7 +144,6 @@ class Buffer:
         return v
 
     def asbytes(self) -> bytes:
-        self.align(4)
         return bytes(self._bytes[0:self._pos])
 
 

--- a/cyclonedds/pub.py
+++ b/cyclonedds/pub.py
@@ -162,6 +162,7 @@ class DataWriter(Entity, Generic[_T]):
             raise TypeError(f"{sample} is not of type {self.data_type}")
 
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
             ret = ddspy_write_ts(self._ref, ser, timestamp)
@@ -173,6 +174,7 @@ class DataWriter(Entity, Generic[_T]):
 
     def write_dispose(self, sample: _T, timestamp: Optional[int] = None):
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
             ret = ddspy_writedispose_ts(self._ref, ser, timestamp)
@@ -184,6 +186,7 @@ class DataWriter(Entity, Generic[_T]):
 
     def dispose(self, sample: _T, timestamp: Optional[int] = None):
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
             ret = ddspy_dispose_ts(self._ref, ser, timestamp)
@@ -204,6 +207,7 @@ class DataWriter(Entity, Generic[_T]):
 
     def register_instance(self, sample: _T) -> int:
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         ret = ddspy_register_instance(self._ref, ser)
         if ret < 0:
@@ -212,6 +216,7 @@ class DataWriter(Entity, Generic[_T]):
 
     def unregister_instance(self, sample: _T, timestamp: Optional[int] = None):
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
             ret = ddspy_unregister_instance_ts(self._ref, ser, timestamp)
@@ -240,6 +245,7 @@ class DataWriter(Entity, Generic[_T]):
 
     def lookup_instance(self, sample: _T) -> Optional[int]:
         ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         ret = ddspy_lookup_instance(self._ref, ser)
         if ret < 0:


### PR DESCRIPTION
As it turns out there were several mistakes in the SDK_KEY implementation, by which keys without CDR header could be added into messages or not properly aligned. It is fixed here by never allowing a keyed bit of data to exist without header in front of it.