### PR TITLE
Enable bounded sequences in fuzzer types

### DIFF
--- a/tests/support_modules/fuzz_tools/rand_idl/containers.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/containers.py
@@ -38,7 +38,7 @@ class RTypeDiscriminator(Enum):
             8,
             8,
             8,
-            0, #todo: allow bounded seqs
+            8,
             0 if no_enums else 1,
             1
         ]


### PR DESCRIPTION
Now that the C code supports bounded sequences, it seems only sensible to also include them here. Not sure whether 8 is the right value to use, I suspect that means it is now generating more sequences. I did have a look at some generated types, and I don't think they have excessively many sequences.

Signed-off-by: Erik Boasson <eb@ilities.com>