### PR TITLE
Add parameter for generator specific config to idlc generation function

### DIFF
--- a/idlpy/include/generator.h
+++ b/idlpy/include/generator.h
@@ -20,7 +20,7 @@
 #if _WIN32
 __declspec(dllexport)
 #endif
-idl_retcode_t generate(const idl_pstate_t *pstate);
+idl_retcode_t generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config);
 
 #if _WIN32
 __declspec(dllexport)

--- a/idlpy/src/generator.c
+++ b/idlpy/src/generator.c
@@ -30,7 +30,7 @@
 const char* prefix_root_module = NULL;
 
 idl_retcode_t
-generate(const idl_pstate_t *pstate)
+generate(const idl_pstate_t *pstate, const idlc_generator_config_t *config)
 {
     idlpy_ctx ctx;
     idl_retcode_t ret = IDL_RETCODE_NO_MEMORY;
@@ -40,6 +40,7 @@ generate(const idl_pstate_t *pstate)
 
     assert(pstate->paths);
     assert(pstate->paths->name);
+    (void) config;
 
     path = pstate->sources->path->name;
     sep = ext = NULL;


### PR DESCRIPTION
In https://github.com/eclipse-cyclonedds/cyclonedds/pull/989 a parameter is added to the IDLC `generate` function signature. This commit adds the parameter to the python generator.