### PR TITLE
Enable enums in fuzzer tests and fix non-primitive arrays in key

### DIFF
--- a/cyclonedds/idl/_builder.py
+++ b/cyclonedds/idl/_builder.py
@@ -78,8 +78,8 @@ class Builder:
                 asubmachine.add_size_header = False
                 asubmachine = asubmachine.submachine
 
-            # TODO: remove Enum and Bitmask here when C also has those
-            if isinstance(asubmachine, (ByteArrayMachine, PlainCdrV2ArrayOfPrimitiveMachine, CharMachine, EnumMachine, BitBoundEnumMachine, BitMaskMachine)):
+            # TODO: remove Bitmask here when C also has that
+            if isinstance(asubmachine, (ByteArrayMachine, PlainCdrV2ArrayOfPrimitiveMachine, CharMachine, BitMaskMachine)):
                 add_size_header = False
 
             return ArrayMachine(
@@ -93,8 +93,8 @@ class Builder:
             if isinstance(submachine, PrimitiveMachine):
                 return PlainCdrV2SequenceOfPrimitiveMachine(submachine.type, max_length=_type.max_length)
 
-            # TODO: remove Enum and Bitmask here when C also has those
-            if isinstance(submachine, (CharMachine, EnumMachine, BitBoundEnumMachine, BitMaskMachine)):
+            # TODO: remove Bitmask here when C also has that
+            if isinstance(submachine, (CharMachine, BitMaskMachine)):
                 add_size_header = False
 
             return SequenceMachine(

--- a/cyclonedds/idl/_machinery.py
+++ b/cyclonedds/idl/_machinery.py
@@ -206,7 +206,7 @@ class ArrayMachine(Machine):
     def serialize(self, buffer, value, for_key=False):
         assert len(value) == self.size
 
-        if self.add_size_header and not for_key:
+        if self.add_size_header:
             buffer.align(4)
             buffer.write('I', 4, 0)
             hpos = buffer.tell()
@@ -214,7 +214,7 @@ class ArrayMachine(Machine):
         for v in value:
             self.submachine.serialize(buffer, v, for_key)
 
-        if self.add_size_header and not for_key:
+        if self.add_size_header:
             mpos = buffer.tell()
             buffer.seek(hpos - 4)
             buffer.write('I', 4, mpos - hpos)
@@ -243,7 +243,8 @@ class ArrayMachine(Machine):
             return [CdrKeyVmOp(CdrKeyVMOpType.Stream4ByteSize, True, size=1, align=4)]
 
         subops = self.submachine.cdr_key_machine_op(skip)
-        return ([CdrKeyVmOp(CdrKeyVMOpType.StreamStatic, True, size=4, align=4)] if self.add_size_header else []) + \
+        return ([CdrKeyVmOp(CdrKeyVMOpType.StreamStatic, skip, size=4, align=4)] if self.add_size_header else []) + \
+            ([CdrKeyVmOp(CdrKeyVMOpType.ByteSwap, skip, align=4)] if not skip and self.add_size_header else []) + \
             [CdrKeyVmOp(CdrKeyVMOpType.RepeatStatic, skip, self.size, value=len(subops) + 2)] + \
             subops + [CdrKeyVmOp(CdrKeyVMOpType.EndRepeat, skip, len(subops))]
 
@@ -264,7 +265,7 @@ class SequenceMachine(Machine):
 
         buffer.align(4)
 
-        if self.add_size_header and not for_key:
+        if self.add_size_header
             buffer.write('I', 4, 0)
             hpos = buffer.tell()
 
@@ -273,7 +274,7 @@ class SequenceMachine(Machine):
         for v in value:
             self.submachine.serialize(buffer, v, for_key)
 
-        if self.add_size_header and not for_key:
+        if self.add_size_header
             mpos = buffer.tell()
             buffer.seek(hpos - 4)
             buffer.write('I', 4, mpos - hpos)
@@ -314,7 +315,8 @@ class SequenceMachine(Machine):
             return [CdrKeyVmOp(CdrKeyVMOpType.Stream4ByteSize, True, size=1, align=4)]
 
         subops = self.submachine.cdr_key_machine_op(skip)
-        return ([CdrKeyVmOp(CdrKeyVMOpType.StreamStatic, True, size=4, align=4)] if self.add_size_header else []) + \
+        return ([CdrKeyVmOp(CdrKeyVMOpType.StreamStatic, skip, size=4, align=4)] if self.add_size_header else []) + \
+            ([CdrKeyVmOp(CdrKeyVMOpType.ByteSwap, skip, align=4)] if not skip and self.add_size_header else []) + \
             [CdrKeyVmOp(CdrKeyVMOpType.Repeat4ByteSize, skip, value=len(subops) + 2)] + \
             subops + [CdrKeyVmOp(CdrKeyVMOpType.EndRepeat, skip, len(subops))]
 

--- a/tests/support_modules/fuzz_tools/rand_idl/generators.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/generators.py
@@ -29,7 +29,7 @@ def emit_type_inner(top_scope: cn.RScope, scope: cn.RScope, random: Random, no_e
         )
 
     elif d == cn.RTypeDiscriminator.Sequence:
-        inner = emit_type(top_scope, scope, random, True)  # TODO allow sequence of enum
+        inner = emit_type(top_scope, scope, random, False)
         rtype = cn.RType(
             discriminator=d,
             inner=inner
@@ -44,7 +44,7 @@ def emit_type_inner(top_scope: cn.RScope, scope: cn.RScope, random: Random, no_e
         return rtype
 
     elif d == cn.RTypeDiscriminator.BoundedSequence:
-        inner = emit_type(top_scope, scope, random, True)  # TODO allow sequence of enum
+        inner = emit_type(top_scope, scope, random, False)
         rtype = cn.RType(
             discriminator=d,
             inner=inner,
@@ -109,7 +109,7 @@ def emit_field(top_scope: cn.RScope, scope: cn.RScope, random: Random) -> cn.RFi
 
     array_bound = None
     # TODO: remove discriminator check if is_fully_descriptive bug is solved and
-    if field_type.discriminator not in [cn.RTypeDiscriminator.BoundedSequence, cn.RTypeDiscriminator.Sequence, cn.RTypeDiscriminator.Enumerator] and random.random() < 0.2:
+    if field_type.discriminator not in [cn.RTypeDiscriminator.BoundedSequence, cn.RTypeDiscriminator.Sequence] and random.random() < 0.2:
         dims = random.randint(1, 2)
         array_bound = [random.randint(1, 3) for i in range(dims)]
 


### PR DESCRIPTION
Enable enum with `@bit_bound` and array-of-enum in keys in fuzzer tests, and add a `DHEADER` for arrays with non-primitive element type in the CDR serializer.
