### PR TITLE
Remove scikit-build

### DIFF
--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -38,7 +38,7 @@ variables:
   CONFIGURE: >-
     mkdir -p build &&
     cd build &&
-    cmake ../main -DCMAKE_INSTALL_PREFIX="$CYCLONEDDS_HOME" -DBUILD_SCHEMA=off -DENABLE_SHM=off -DENABLE_SSL=off -DENABLE_SECURITY=off -DENABLE_TOPIC_DISCOVERY=on -DENABLE_TYPE_DISCOVERY=on
+    cmake ../main -DCMAKE_INSTALL_PREFIX="$CYCLONEDDS_HOME" -DBUILD_SCHEMA=off -DENABLE_SHM=off -DENABLE_SSL=on -DENABLE_SECURITY=on -DENABLE_TOPIC_DISCOVERY=on -DENABLE_TYPE_DISCOVERY=on
   BUILD: >-
     cmake --build . --target install
   CIBW_BEFORE_ALL: >-
@@ -48,16 +48,16 @@ variables:
     auditwheel repair -w {dest_dir} {wheel}
   CIBW_ENVIRONMENT_LINUX: >-
     CYCLONEDDS_HOME=/project/install
-    CMAKE_PREFIX_PATH=/project/install
     LD_LIBRARY_PATH=/project/install/lib:/project/install/lib64
+    STANDALONE_WHEELS=1
   # ---- MACOS ----
   CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
     DYLD_LIBRARY_PATH=$(Build.Repository.LocalPath)/install/lib delocate-listdeps {wheel} &&
     DYLD_LIBRARY_PATH=$(Build.Repository.LocalPath)/install/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
   CIBW_ENVIRONMENT_MACOS: >-
     CYCLONEDDS_HOME=$(Build.Repository.LocalPath)/install
-    CMAKE_PREFIX_PATH=$(Build.Repository.LocalPath)/install
     DYLD_LIBRARY_PATH=$(Build.Repository.LocalPath)/install/lib
+    STANDALONE_WHEELS=1
   # ---- WINDOWS ----
   CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
     pip install delvewheel==0.0.14 &&
@@ -93,9 +93,9 @@ jobs:
          $(CLONE) && $(CONFIGURE) -A Win32 && $(BUILD)
   steps:
   - pwsh: |
+      Write-Host "###vso[task.setvariable variable=STANDALONE_WHEELS;]1"
       Write-Host "###vso[task.setvariable variable=PATH;]$(Build.Repository.LocalPath)\\install\\bin;${env:PATH}"
       Write-Host "###vso[task.setvariable variable=CYCLONEDDS_HOME;]$(Build.Repository.LocalPath)\install"
-      Write-Host "###vso[task.setvariable variable=CMAKE_PREFIX_PATH;]$(Build.Repository.LocalPath)\install"
       $a = "${env:CIBW_BEFORE_ALL_WINDOWS_PRE}" -replace "\`$CYCLONEDDS_HOME","$(Build.Repository.LocalPath)\install"
       Write-Host "###vso[task.setvariable variable=CIBW_BEFORE_ALL_WINDOWS;]$a"
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -128,4 +128,3 @@ jobs:
       find artifacts/ -name "*.whl" -exec mv {} wheelhouse \;
     displayName: Collect wheels for publication
   - template: /.azure/templates/publish-package.yml
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom
+cyclonedds/__library__.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ pip3 install --user .[dev]
 $ pip3 install --user .[docs]
 ```
 
-While the quickest way to get going is the `--user` flag it is not the recommended, we recommend using [a virtual environment][2], [poetry][3], [pipenv][4] or [pyenv][5]. After the installation is complete `import cyclonedds` should now work. The `CYCLONEDDS_HOME` variable is essential for the Python backend to locate the CycloneDDS binaries so this always needs to be set when running Python code with Cyclone DDS. Have a look at the [examples](examples/) to learn about how to use the Python API.
+While the quickest way to get going is the `--user` flag it is not the recommended, we recommend using [a virtual environment][2], [poetry][3], [pipenv][4] or [pyenv][5]. After the installation is complete `import cyclonedds` should now work. Have a look at the [examples](examples/) to learn about how to use the Python API.
 
 You can also run the idl compiler in Python mode if it the Python package is installed. Simply run `idlc -l py file.idl` and a Python module with your types will be generated in the current working directory. If you wish to nest the resulting Python module inside an existing package you can specify the path from the intended root. So if you have a package 'wubble' with a submodule 'fruzzy' and want the generated modules and types under there you can do `idlc -l py -p py-root-prefix=wubble.fruzzy file.idl`.
 

--- a/buildhelp/bdist_wheel.py
+++ b/buildhelp/bdist_wheel.py
@@ -1,0 +1,39 @@
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+from cyclone_search import find_cyclonedds
+from pathlib import Path
+import shutil
+import os
+
+
+class bdist_wheel(_bdist_wheel):
+    def initialize_options(self):
+        self.standalone = os.environ.get("STANDALONE_WHEELS") == "1"
+        super().initialize_options()
+
+    def finalize_options(self):
+        if self.standalone:
+            self.distribution.entry_points["console_scripts"].append("idlc=cyclonedds.tools.wheel_idlc:command")
+        super().finalize_options()
+
+    def run(self):
+        if self.standalone:
+            cyclone = find_cyclonedds()
+
+            newlibdir = Path(self.bdist_dir) / 'cyclonedds' / '.libs'
+
+            os.makedirs(newlibdir, exist_ok=True)
+            with open(Path(self.bdist_dir) / 'cyclonedds' / '__library__.py', "w", encoding='utf-8') as f:
+                f.write("from pathlib import Path\n\n")
+                f.write("in_wheel = True\n")
+                f.write(f"library_path = Path(__file__).parent / '.libs' / '{cyclone.ddsc_library.name}'")
+
+            shutil.copy(cyclone.ddsc_library, newlibdir / cyclone.ddsc_library.name)
+
+            if cyclone.idlc_executable and cyclone.idlc_library:
+                shutil.copy(cyclone.idlc_executable, newlibdir / cyclone.idlc_executable.name)
+                shutil.copy(cyclone.idlc_library, newlibdir / cyclone.idlc_library.name)
+
+            for lib in cyclone.security_libs:
+                shutil.copy(lib, newlibdir / lib.name)
+
+        super().run()

--- a/buildhelp/build_ext.py
+++ b/buildhelp/build_ext.py
@@ -1,0 +1,19 @@
+from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools import Extension
+
+
+class Library(Extension):
+    pass
+
+
+class build_ext(_build_ext):
+    def get_libraries(self, ext):
+        if isinstance(ext, Library):
+            return ext.libraries
+        return super().get_libraries(ext)
+
+    def get_export_symbols(self, ext):
+        if isinstance(ext, Library):
+            return ext.export_symbols
+        return super().get_export_symbols(ext)
+

--- a/buildhelp/cyclone_search.py
+++ b/buildhelp/cyclone_search.py
@@ -1,0 +1,121 @@
+"""
+ * Copyright(c) 2022 ZettaScale Technology and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+"""
+import os
+import platform
+from pathlib import Path
+from typing import List, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class FoundCycloneResult:
+    home: Path
+    library_path: Path
+    include_path: Path
+    binary_path: Path
+    ddsc_library: Path
+    idlc_executable: Optional[Path]
+    idlc_library: Optional[Path]
+    security_libs: List[Path]
+
+
+def first_or_none(alist):
+    alist = list(alist)
+    if alist:
+        return alist[0]
+
+
+def good_directory(directory: Path):
+    dir = directory.resolve()
+    if not dir.exists():
+        return
+
+    include_path = dir / 'include'
+    bindir = dir / 'bin'
+
+    if not include_path.exists() or not bindir.exists():
+        return
+
+    libdir = dir / 'lib'
+    if not libdir.exists():
+        libdir = dir / 'lib64'
+        if not libdir.exists():
+            return None
+
+    if platform.system() == 'Windows':
+        ddsc_library = bindir / "ddsc.dll"
+    elif platform.system() == 'Darwin':
+        ddsc_library = libdir / "libddsc.dylib"
+    else:
+        ddsc_library = libdir / "libddsc.so"
+
+    if not ddsc_library.exists():
+        return None
+
+    idlc_executable = first_or_none(bindir.glob("idlc*"))
+    idlc_library = first_or_none(libdir.glob('libcycloneddsidl*')) or first_or_none(bindir.glob("cycloneddsidl*"))
+    security_libs = list(libdir.glob("*dds_security_*")) + list(bindir.glob("*dds_security_*"))
+
+    return FoundCycloneResult(
+        home=dir,
+        include_path=include_path,
+        library_path=libdir,
+        binary_path=bindir,
+        ddsc_library=ddsc_library,
+        idlc_executable=idlc_executable,
+        idlc_library=idlc_library,
+        security_libs=security_libs
+    )
+
+
+def search_cyclone_pathlike(pathlike, upone=False):
+    for path in pathlike.split(os.pathsep):
+        if upone:
+            return good_directory(Path(path) / '..')
+        else:
+            return good_directory(Path(path))
+
+
+def find_cyclonedds() -> Optional[FoundCycloneResult]:
+    if "CYCLONEDDS_HOME" in os.environ:
+        dir = good_directory(Path(os.environ["CYCLONEDDS_HOME"]))
+        if dir:
+            return dir
+    if "CycloneDDS_ROOT" in os.environ:
+        dir = good_directory(Path(os.environ["CMAKE_CycloneDDS_ROOT"]))
+        if dir:
+            return dir
+    if "CycloneDDS_ROOT" in os.environ:
+        dir = good_directory(Path(os.environ["CycloneDDS_ROOT"]))
+        if dir:
+            return dir
+    if "CMAKE_PREFIX_PATH" in os.environ:
+        dir = search_cyclone_pathlike(os.environ["CMAKE_PREFIX_PATH"])
+        if dir:
+            return dir
+    if "CMAKE_LIBRARY_PATH" in os.environ:
+        dir = search_cyclone_pathlike(os.environ["CMAKE_LIBRARY_PATH"])
+        if dir:
+            return dir
+    if platform.system() != "Windows" and "LIBRARY_PATH" in os.environ:
+        dir = search_cyclone_pathlike(os.environ["LIBRARY_PATH"], upone=True)
+        if dir:
+            return dir
+    if platform.system() != "Windows" and "LD_LIBRARY_PATH" in os.environ:
+        dir = search_cyclone_pathlike(os.environ["LD_LIBRARY_PATH"], upone=True)
+        if dir:
+            return dir
+    if platform.system() == "Windows" and "PATH" in os.environ:
+        dir = search_cyclone_pathlike(os.environ["PATH"], upone=True)
+        if dir:
+            return dir
+

--- a/cyclonedds/__idlc__.py
+++ b/cyclonedds/__idlc__.py
@@ -10,21 +10,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 """
 
-from os import path, listdir
 from sys import exit
+from pathlib import Path
 
 
-dir = path.abspath(path.join(path.dirname(__file__), ".libs"))
-libs = [f for f in listdir(dir) if "idl" in f]
-
-if not libs:
-    idlpy_lib = None
-else:
-    idlpy_lib = path.join(dir, libs[0])
+idlpy_path = list(Path(__file__).resolve().parent.glob("_idlpy*"))[0]
 
 
 if __name__ == "__main__":
-    if not idlpy_lib:
-        exit(1)
-    print(idlpy_lib, end="", flush=True)
+    print(idlpy_path, end="", flush=True)
     exit(0)

--- a/cyclonedds/tools/wheel_idlc/__init__.py
+++ b/cyclonedds/tools/wheel_idlc/__init__.py
@@ -11,36 +11,33 @@
 
 
 This tool is used in wheels to perform the idlc command.
-The idlc binary is under cyclonedds/.bin/idlc, libs are under
+The idlc binary is under cyclonedds/.libs/idlc, libs are under
 cyclonedds/.libs.
 """
 
 import os
 import sys
 import platform
-import subprocess
 import cyclonedds
+from pathlib import Path
 
-basedir = os.path.abspath(os.path.dirname(cyclonedds.__file__))
-idlc = os.path.join(basedir, ".bin", "idlc")
-if platform.system() == "Windows":
-    idlc += ".exe"
 
-libdir = os.path.join(basedir, ".libs")
+libdir = Path(__file__).resolve().parent / '.libs'
+idlc = (libdir / 'idlc.exe') if platform.system() == "Windows" else (libdir / 'idlc')
 
 
 def command():
-    if not os.path.exists(idlc):
+    if not idlc.exists():
         print("Python idlc entrypoint active but cyclonedds-python installation does not include idlc executable!")
         sys.exit(1)
 
     environ = os.environ.copy()
 
     if platform.system() == "Windows":
-        environ["PATH"] = ";".join([libdir] + environ.get("PATH", "").split(";"))
+        environ["PATH"] = ";".join([str(libdir)] + environ.get("PATH", "").split(";"))
     elif platform.system() == "Darwin":
-        environ["DYLD_LIBRARY_PATH"] = ":".join([libdir] + environ.get("DYLD_LIBRARY_PATH", "").split(":"))
+        environ["DYLD_LIBRARY_PATH"] = ":".join([str(libdir)] + environ.get("DYLD_LIBRARY_PATH", "").split(":"))
     else:
-        environ["LD_LIBRARY_PATH"] = ":".join([libdir] + environ.get("LD_LIBRARY_PATH", "").split(":"))
+        environ["LD_LIBRARY_PATH"] = ":".join([str(libdir)] + environ.get("LD_LIBRARY_PATH", "").split(":"))
 
     os.execvpe(idlc, sys.argv[1:], environ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,8 @@ requires-python = ">=3.7"
 
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
-    "scikit-build",
-    "cmake>=3.18.0",
-    "ninja"
+    "setuptools>=42.0.2",
+    "wheel>=0.29.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,7 @@
 from cyclonedds.internal import CycloneDDSLoaderException, load_cyclonedds
+from cyclonedds.__library__ import library_path
 from pytest_mock import MockerFixture
+import os
 
 
 def gen_test_loader(loadlist):
@@ -20,10 +22,6 @@ def common_mocks(mocker: MockerFixture, platform: str, ext: str):
     mocker.patch("ctypes.util.find_library", new=lambda x: None)
     mocker.patch("cyclonedds.internal._load", new=gen_test_loader(loadlist))
     mocker.patch("platform.system", new=lambda: platform)
-    mocker.patch("os.path.join", new=gen_joiner("\\" if platform == "Windows" else "/"))
-    mocker.patch("os.path.exists", new=lambda p: True)
-    mocker.patch("os.listdir", new=lambda p: [f"libddsc_listdir_canary{ext}"])
-    mocker.patch("os.path.dirname", new=lambda f: "dirname_canary")
     mocker.patch("os.environ", new={"CYCLONEDDS_HOME": "env_canary", "PATH": ""})
     return loadlist
 
@@ -36,9 +34,9 @@ def test_loading_linux(mocker: MockerFixture):
         pass
 
     assert paths == [
-        "dirname_canary/../cyclonedds.libs/libddsc_listdir_canary.so",
-        "env_canary/lib/libddsc.so",
-        "libddsc.so"
+        f"env_canary{os.sep}lib{os.sep}libddsc.so",
+        "libddsc.so",
+        library_path
     ]
 
 
@@ -50,9 +48,9 @@ def test_loading_macos(mocker):
         pass
 
     assert paths == [
-        "dirname_canary/.dylibs/libddsc_listdir_canary.dylib",
-        "env_canary/lib/libddsc.dylib",
+        f"env_canary{os.sep}lib{os.sep}libddsc.dylib",
         "libddsc.dylib",
+        library_path
     ]
 
 
@@ -64,7 +62,7 @@ def test_loading_windows(mocker):
         pass
 
     assert paths == [
-        "dirname_canary\\..\\cyclonedds.libs\\libddsc_listdir_canary.dll",
-        "env_canary\\bin\\ddsc.dll",
-        "ddsc.dll"
+        f"env_canary{os.sep}bin{os.sep}ddsc.dll",
+        "ddsc.dll",
+        library_path
     ]


### PR DESCRIPTION
This PR removes scikit-build and builds with normal python tools instead. Scikit-build caused some unhappyness for a while, for me but also @pleyer has let us know about it in #35. Now pushed by a situation where scikit-build really doesn't work at all as reported by @pscheie in #52 and #53 I have removed it. As you can tell there is a little more build scripting needed as added in the buildhelp install-time package.

@pleyer, if you are still around, would you mind testing this PR with your yocto build?

Fixes #35, Fixes #52, Fixes #53 