### PR TITLE
Fix using enums as union discriminators

### DIFF
--- a/clayer/pysertype.c
+++ b/clayer/pysertype.c
@@ -859,6 +859,7 @@ static ddspy_sertype_t *ddspy_sertype_new(PyObject *pytype)
 
     new = (ddspy_sertype_t*) dds_alloc(sizeof(ddspy_sertype_t));
 
+    Py_INCREF(pytype);
     new->my_py_type = pytype;
     new->keyless = keyless;
     new->is_v2_by_default = pyxcdrv2 == Py_True;
@@ -938,7 +939,6 @@ static ddspy_sertype_t *ddspy_sertype_new(PyObject *pytype)
         keyless
     );
     constructed = true;
-    Py_INCREF(pytype);
 
 err:
     if (new && !constructed) {

--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -1133,6 +1133,8 @@ class XTBuilder:
 
     @classmethod
     def _xt_union_case_label_seq(cls, entity: Type[IdlUnion], name: str, _type: Type[Any]) -> xt.UnionCaseLabelSeq:
+        if isclass(entity.__idl_discriminator__) and issubclass(entity.__idl_discriminator__, IdlEnum):
+            return [l.value for l in _type.labels] if isinstance(_type, pt.case) else []
         return _type.labels if isinstance(_type, pt.case) else []
 
     @classmethod

--- a/tests/test_enum_as_discriminator.py
+++ b/tests/test_enum_as_discriminator.py
@@ -1,0 +1,23 @@
+from cyclonedds.domain import DomainParticipant
+from cyclonedds.topic import Topic
+from cyclonedds.pub import DataWriter
+from cyclonedds.idl import IdlEnum, IdlUnion
+from cyclonedds.idl.types import case
+
+
+class MyEnum(IdlEnum):
+    A = 1
+    B = 0
+
+
+class MyUnion(IdlUnion, discriminator=MyEnum):
+    a: case[MyEnum.A, int]
+    b: case[MyEnum.B, str]
+
+
+def test_enum_as_discriminator():
+    dp = DomainParticipant(0)
+    tp = Topic(dp, 'EnumDiscrTopic', MyUnion)
+    dw = DataWriter(dp, tp)
+    dw.write(MyUnion(a=9))
+    dw.write(MyUnion(b="Hello"))


### PR DESCRIPTION
In python an enum value is not implicitly convertable to an integer and that is sometimes good and sometimes it results in these little bugs. I also caught a refcount bug by accident.