### PR TITLE
Add DHEADER for sequences/arrays of bitmasks

### DIFF
--- a/cyclonedds/idl/_builder.py
+++ b/cyclonedds/idl/_builder.py
@@ -78,8 +78,7 @@ class Builder:
                 asubmachine.add_size_header = False
                 asubmachine = asubmachine.submachine
 
-            # TODO: remove Bitmask here when C also has that
-            if isinstance(asubmachine, (ByteArrayMachine, PlainCdrV2ArrayOfPrimitiveMachine, CharMachine, BitMaskMachine)):
+            if isinstance(asubmachine, (ByteArrayMachine, PlainCdrV2ArrayOfPrimitiveMachine, CharMachine)):
                 add_size_header = False
 
             return ArrayMachine(
@@ -93,8 +92,7 @@ class Builder:
             if isinstance(submachine, PrimitiveMachine):
                 return PlainCdrV2SequenceOfPrimitiveMachine(submachine.type, max_length=_type.max_length)
 
-            # TODO: remove Bitmask here when C also has that
-            if isinstance(submachine, (CharMachine, BitMaskMachine)):
+            if isinstance(submachine, (CharMachine)):
                 add_size_header = False
 
             return SequenceMachine(

--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -1346,7 +1346,6 @@ class XTBuilder:
             cls._xt_complete_enumerated_literal(entity, entry)
             for entry in entity
         ]
-        return seq  # TODO REMOVE WHEN FIXED ON C SIDE
         return list(sorted(seq, key=lambda x: x.common.value))
 
     @classmethod
@@ -1355,7 +1354,6 @@ class XTBuilder:
             cls._xt_minimal_enumerated_literal(entity, entry)
             for entry in entity
         ]
-        return seq  # TODO REMOVE WHEN FIXED ON C SIDE
         return list(sorted(seq, key=lambda x: x.common.value))
 
     @classmethod


### PR DESCRIPTION
This removes a workaround for a deficiency in the C serializer.

It also removes an old TODO that — to me — appears as if it should have removed some time ago already.