### PR TITLE
Make sure coverage always runs, even if fuzzer fails.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,7 @@ jobs:
   - template: /.azure/templates/build-test.yml
 - job: CoverageReport
   dependsOn: RuntimeTests
+  condition: succeededOrFailed()
   pool:
     vmImage: ubuntu-20.04
   steps:
@@ -117,7 +118,7 @@ jobs:
       ls coverage
       pip install --user coverage
       python -m coverage combine ./coverage/*/.coverage
-      python -m coverage xml
+      python -m coverage xml --ignore-errors --skip-empty --omit="**/__library__.py"
   - task: PublishCodeCoverageResults@1
     displayName: Publish Cobertura Coverage Report
     inputs:


### PR DESCRIPTION
This always runs the coverage job, even if some fuzzer tasks fail. Also explictly ignore the __library__ file, which is autogenerated and doesn't exist in the source, causing an error even if the fuzzer succeeds at the moment.