### PR TITLE
Make mutation errors non-fatal by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def fuzzing_config(pytestconfig) -> FuzzingConfig:
         name, value = arg.split('=')
         if name in ["num_types", "num_samples", "type_seed", "skip_types"]:
             value = int(value)
-        elif name in ["store_reproducers"]:
+        elif name in ["store_reproducers", "mutation_failure_fatal"]:
             value = bool(value)
         elif name in ["idl_file", "typenames"]:
             pass

--- a/tests/support_modules/test_tools/fixtures.py
+++ b/tests/support_modules/test_tools/fixtures.py
@@ -96,7 +96,8 @@ class FuzzingConfig:
             type_seed: int = 1,
             idl_file: Optional[str] = None,
             typenames: Optional[str] = None,
-            skip_types: int = 0
+            skip_types: int = 0,
+            mutation_failure_fatal: bool = False
         ) -> None:
         self.num_types: int = num_types
         self.num_samples: int = num_samples
@@ -105,3 +106,4 @@ class FuzzingConfig:
         self.idl_file: Optional[str] = idl_file
         self.typenames: Optional[List[str]] = None if typenames is None else typenames.split(',')
         self.skip_types: int = skip_types
+        self.mutation_failure_fatal: bool = mutation_failure_fatal


### PR DESCRIPTION
This makes it so mutation failures are still printed but the CI doesn't fail on them. Locally we can run with `--fuzzing mutation_failure_fatal=1` to ensure we don't miss anything, but currently the assignibility checking in python is too inaccurate to make it a hard failure. If at some point python has a full assignibility implementation we'll switch the CI behaviour around again.