### PR TITLE
Support entity name QoS Policy in Python

### DIFF
--- a/tests/test_qos.py
+++ b/tests/test_qos.py
@@ -54,6 +54,7 @@ some_qosses = [
     Qos(Policy.DataRepresentation(use_cdrv0_representation=True)),
     Qos(Policy.DataRepresentation(use_xcdrv2_representation=True)),
     Qos(Policy.DataRepresentation(use_cdrv0_representation=True, use_xcdrv2_representation=True)),
+    Qos(Policy.EntityName("dihydrogenmonoxide"))
 ]
 
 qos_pairs = list(itertools.combinations(some_qosses, 2))


### PR DESCRIPTION
Add support for Entity Naming QoS Policy as added for C in [eclipse-cyclonedds#1225](https://github.com/eclipse-cyclonedds/cyclonedds/pull/1225)