### PR TITLE
Removed several assert() statements in idlpy context.c file 

### DIFF
--- a/idlpy/src/context.c
+++ b/idlpy/src/context.c
@@ -180,7 +180,6 @@ void idlpy_ctx_free(idlpy_ctx octx)
     assert(octx->basepath);
     assert(octx->idl_file);
     assert(octx->module != NULL);
-    assert(octx->toplevel_module != NULL);
     assert(octx->root_module != NULL);
     assert(octx->entity == NULL);
 
@@ -529,8 +528,6 @@ static void write_pyfile_finish(idlpy_ctx octx)
     assert(octx->module);
     assert(octx->module->fullname);
     assert(octx->module->fp);
-    assert(octx->entity);
-    assert(octx->entity->name);
 
     FILE *cache, *real;
     int c;
@@ -598,8 +595,6 @@ static void write_toplevel_pyfile_finish(idlpy_ctx octx)
     assert(octx->module);
     assert(octx->module->fullname);
     assert(octx->module->fp);
-    assert(octx->entity);
-    assert(octx->entity->name);
 
     FILE *cache, *real;
     int c;


### PR DESCRIPTION
On Windows (MSVC, debug build), several asserts are triggered when idlc is called for Python. However, these do not seem to be necessary or valid. I removed them and the generator works for debug builds as well.
By the way, I had to manually build the generator plugin with debug information, since setup.py only generates release builds. And the debug version of idlc does not work with the release build of the plugin.