### PR TITLE
Azure Pipelines: 'pr' is not part of 'trigger', it is a separate entry

### DIFF
--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -18,10 +18,11 @@ trigger:
   tags:
     include:
     - '*'
-  pr: none
   branches:
     exclude:
     - '*'
+
+pr: none
 
 
 variables:


### PR DESCRIPTION
Some warnings popped out of the CI because of this detail.