### PR TITLE
Small fixes for CI, sync with C

### DIFF
--- a/clayer/pysertype.c
+++ b/clayer/pysertype.c
@@ -977,6 +977,10 @@ ddspy_topic_create(PyObject *self, PyObject *args)
 
     sts = dds_create_topic_sertype(participant, name, (struct ddsi_sertype **) &sertype, qos, listener, NULL);
 
+    if (PyErr_Occurred() || sts < 0) {
+        ddsi_sertype_unref(sertype);
+    }
+
     if (PyErr_Occurred()) return NULL;
 
     return PyLong_FromLong((long)sts);

--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -16,8 +16,6 @@ from collections import deque
 from dataclasses import dataclass
 from hashlib import md5
 
-from cyclonedds.internal import uint32_max
-
 from ._typesupport.DDS import XTypes as xt
 from . import types as pt
 from . import annotations as annotate
@@ -25,6 +23,9 @@ from . import IdlStruct, IdlUnion, IdlBitmask, IdlEnum, make_idl_struct, make_id
 from ._support import Endianness
 from ._type_helper import get_origin, get_args
 from ._type_normalize import get_extended_type_hints, get_idl_annotations, get_idl_field_annotations, WrapOpt
+
+
+uint32_max = 2 ** 32 - 1
 
 
 def _is_optional(_type: Any) -> bool:
@@ -676,7 +677,7 @@ class XTBuilder:
                 fully_descriptive = cls._impl_xt_is_fully_descriptive(entity)
                 header = xt.PlainCollectionHeader(
                     equiv_kind=xt.EK_BOTH if fully_descriptive else (xt.EK_MINIMAL if minimal else xt.EK_COMPLETE),
-                    element_flags=xt.MemberFlag()  # TODO: elements can be external, try_construct
+                    element_flags=xt.MemberFlag(TRY_CONSTRUCT1=True)  # TODO: elements can be external, try_construct
                 )
 
                 if entity.max_length is None:
@@ -708,7 +709,7 @@ class XTBuilder:
                 fully_descriptive = cls._impl_xt_is_fully_descriptive(entity)
                 header = xt.PlainCollectionHeader(
                     equiv_kind=xt.EK_BOTH if fully_descriptive else (xt.EK_MINIMAL if minimal else xt.EK_COMPLETE),
-                    element_flags=xt.MemberFlag()  # TODO: elements can be external, try_construct
+                    element_flags=xt.MemberFlag(TRY_CONSTRUCT1=True)  # TODO: elements can be external, try_construct
                 )
 
                 inner: Type[Any] = entity
@@ -978,6 +979,10 @@ class XTBuilder:
 
         # TRY CONSTRUCT TODO: INVALID, DISCARD, TRIM?
         if "default" in annotations:
+            # 10 = use_default
+            flag.TRY_CONSTRUCT2 = True
+        else:
+            # 01 = discard
             flag.TRY_CONSTRUCT1 = True
 
         if annotations.get("external", False):
@@ -1074,7 +1079,7 @@ class XTBuilder:
     @classmethod
     def _xt_common_discriminator_member(cls, entity: Type[IdlUnion], minimal: bool) -> xt.CommonDiscriminatorMember:
         return xt.CommonDiscriminatorMember(
-            member_flags=xt.MemberFlag(IS_KEY=entity.__idl_discriminator_is_key__, IS_MUST_UNDERSTAND=True),
+            member_flags=xt.MemberFlag(IS_KEY=entity.__idl_discriminator_is_key__, IS_MUST_UNDERSTAND=True, TRY_CONSTRUCT1=True),
             type_id=cls._xt_type_identifier("discriminator", entity.__idl_discriminator__, minimal)
         )
 
@@ -1142,7 +1147,7 @@ class XTBuilder:
         return xt.MinimalSequenceType(
             collection_flag=xt.TypeFlag(),  # Unused, no flags apply
             header=cls._xt_minimal_collection_header(seq),
-            element=cls._xt_minimal_collection_element(seq.subtype)
+            element=cls._xt_minimal_collection_element(seq.subtype, xt.TypeFlag(TRY_CONSTRUCT1=True))
         )
 
     @classmethod
@@ -1150,7 +1155,7 @@ class XTBuilder:
         return xt.CompleteSequenceType(
             collection_flag=xt.TypeFlag(),  # Unused, no flags apply
             header=cls._xt_complete_collection_header(seq),
-            element=cls._xt_complete_collection_element(seq.subtype)
+            element=cls._xt_complete_collection_element(seq.subtype, xt.TypeFlag(TRY_CONSTRUCT1=True))
         )
 
     @classmethod
@@ -1173,15 +1178,15 @@ class XTBuilder:
         )
 
     @classmethod
-    def _xt_minimal_collection_element(cls, _type: Any) -> xt.MinimalCollectionElement:
+    def _xt_minimal_collection_element(cls, _type: Any, flags: xt.TypeFlag) -> xt.MinimalCollectionElement:
         return xt.MinimalCollectionElement(
-            common=cls._xt_common_collection_element(_type, True)
+            common=cls._xt_common_collection_element(_type, True, flags)
         )
 
     @classmethod
-    def _xt_complete_collection_element(cls, _type: Any) -> xt.CompleteCollectionElement:
+    def _xt_complete_collection_element(cls, _type: Any, flags: xt.TypeFlag) -> xt.CompleteCollectionElement:
         return xt.CompleteCollectionElement(
-            common=cls._xt_common_collection_element(_type, True),
+            common=cls._xt_common_collection_element(_type, True, flags),
             detail=cls._xt_complete_element_detail(_type)
         )
 
@@ -1193,11 +1198,11 @@ class XTBuilder:
         )
 
     @classmethod
-    def _xt_common_collection_element(cls, _type: Any, minimal: bool) -> xt.CommonCollectionElement:
+    def _xt_common_collection_element(cls, _type: Any, minimal: bool, flags: xt.TypeFlag) -> xt.CommonCollectionElement:
         # TODO: how to scope this? Annotations can only be on the parent object,
         # how to get the try_construct/external flags here?
         return xt.CommonCollectionElement(
-            element_flags=xt.TypeFlag(),
+            element_flags=flags,
             type=cls._xt_type_identifier("anonymous", _type, minimal)
         )
 
@@ -1210,7 +1215,7 @@ class XTBuilder:
         return xt.MinimalArrayType(
             collection_flag=xt.TypeFlag(),  # Unused, no flags apply
             header=cls._xt_minimal_array_header(arr),
-            element=cls._xt_minimal_collection_element(inner)
+            element=cls._xt_minimal_collection_element(inner, xt.TypeFlag(TRY_CONSTRUCT1=True))
 
         )
 
@@ -1223,7 +1228,7 @@ class XTBuilder:
         return xt.CompleteArrayType(
             collection_flag=xt.TypeFlag(),  # Unused, no flags apply
             header=cls._xt_complete_array_header(arr),
-            element=cls._xt_complete_collection_element(inner)
+            element=cls._xt_complete_collection_element(inner, xt.TypeFlag(TRY_CONSTRUCT1=True))
 
         )
 

--- a/cyclonedds/qos.py
+++ b/cyclonedds/qos.py
@@ -1994,6 +1994,12 @@ class _CQos(DDS):
         if not cls._get_entity_name(qos, ct.byref(cls._gc_prop_get_value)):
             return None
 
+        if cls._gc_prop_get_value is None or cls._gc_prop_get_value.value is None:
+            return None
+
+        if type(cls._gc_prop_get_value.value) != bytes:
+            return None
+
         name = cls._gc_prop_get_value.value.decode('utf8')
         cls.free(cls._gc_prop_get_value)
 

--- a/tests/support_modules/fuzz_tools/checks/keys.py
+++ b/tests/support_modules/fuzz_tools/checks/keys.py
@@ -84,7 +84,7 @@ def check_py_c_key_equivalence(log: Stream, ctx: FullContext, typename: str, num
             return False
         time.sleep(0.001)
 
-    time.sleep(0.2)
+    time.sleep(0.5)
 
     for sample in samples:
         dw.write(sample)
@@ -96,6 +96,8 @@ def check_py_c_key_equivalence(log: Stream, ctx: FullContext, typename: str, num
     if not hashes:
         log << f"C-app did not return output, stderr:" << log.endl << log.indent
         log << ctx.c_app.last_error << log.endl
+        log << f"stdout:" << log.endl
+        log << ctx.c_app.last_out << log.endl
         log << log.dedent << "Example sample sent:" << log.endl << log.indent
         log << samples[0] << log.endl << samples[0].serialize()
         log << log.dedent
@@ -103,7 +105,9 @@ def check_py_c_key_equivalence(log: Stream, ctx: FullContext, typename: str, num
 
     if len(hashes) != len(samples):
         log << f"C-app did not return as many samples as were sent, stderr:" << log.endl << log.indent
-        log << ctx.c_app.last_error << log.endl << log.dedent
+        log << ctx.c_app.last_error << log.endl
+        log << f"stdout:" << log.endl
+        log << ctx.c_app.last_out << log.endl << log.dedent
         log << log.dedent << "Example sample sent:" << log.endl << log.indent
         log << samples[0] << log.endl << samples[0].serialize()
         success = False

--- a/tests/support_modules/fuzz_tools/checks/mutated.py
+++ b/tests/support_modules/fuzz_tools/checks/mutated.py
@@ -197,7 +197,10 @@ def check_enforced_non_communication(log: Stream, ctx: FullContext, typename: st
     mutated_ctx = FullContext(new_scope)
     mutated_datatype = mutated_ctx.get_datatype(typename)
 
-    if narrow_ctx.idl_file[1:] == mutated_ctx.idl_file[1:]:
+    normal_without_header_idl = "\n".join(narrow_ctx.idl_file.splitlines()[1:])
+    mutated_without_header_idl = "\n".join(mutated_ctx.idl_file.splitlines()[1:])
+
+    if normal_without_header_idl == mutated_without_header_idl:
         # No mutation took place (only unions) just assume it is good
         return True
 

--- a/tests/support_modules/fuzz_tools/checks/mutated.py
+++ b/tests/support_modules/fuzz_tools/checks/mutated.py
@@ -149,6 +149,8 @@ def check_mutation_key(log: Stream, ctx: FullContext, typename: str, num_samples
     if not hashes:
         log << f"C-app did not return output, stderr:" << log.endl << log.indent
         log << ctx.c_app.last_error << log.endl
+        log << f"stdout:" << log.endl
+        log << ctx.c_app.last_out << log.endl
         log << log.dedent << "Example Mutated sample sent:" << log.endl << log.indent
         log << samples[0] << samples[0].serialize()
         log << log.dedent << "[Mutated IDL]:" << log.indent << log.endl

--- a/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
+++ b/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
@@ -82,6 +82,7 @@ int main(int argc, char **argv)
         hex_buff = (char*) realloc(hex_buff, hex_buff_size);
         tohex(descriptor->type_mapping.data, descriptor->type_mapping.sz, hex_buff, hex_buff_size);
         printf("%s\n", hex_buff);
+        fflush(stdout);
         return 0;
     }
 
@@ -125,7 +126,7 @@ int main(int argc, char **argv)
 
             tohex(keystream.x.m_buffer, keystream.x.m_index, hex_buff, hex_buff_size);
 
-            printf("%s\n", hex_buff);
+            printf("0x%s\n", hex_buff);
 
             seqq++;
         }

--- a/tests/test_ddsls.py
+++ b/tests/test_ddsls.py
@@ -460,7 +460,7 @@ def test_ddsls_write_disposed_data_to_file(tmp_path):
         await asyncio.sleep(1)
         return disposed_data
 
-    procdata, disposed_data = run_ddsls_watchmode(["--json", "-a", "-w", "--filename", str(tmp_path / "test_disposed.json")],
+    procdata, disposed_data = run_ddsls_watchmode(["--json", "-a", "--filename", str(tmp_path / "test_disposed.json")],
                                            test_inner, runtime=2)
 
     assert procdata['status'] == 0


### PR DESCRIPTION
This has become a little bit of a hodgepodge of changes, but at least they are still grouped by commit!

 * Commit 015deb8 syncs the TRY_CONSTRUCT flags with C PR https://github.com/eclipse-cyclonedds/cyclonedds/pull/1242
 * Commit 2191b9e fixes a leak in the python sertype where a `ddsi_sertype` does not get unref'ed when a topic creation fails.
 * Commit 672f459 fixes a small mistake in TypeObjects of unions with an Enum as discriminator
 * Commit 43e9b2c fixes a mistake that only occurs on windows where the C api can return NULL from an entity name while claiming it is present. This is dealing with the symptom though, I am not exactly sure why it occurs (it doesn't reproduce locally for me, only on CI...)

This _should_ make the CI fully green again, provided the fuzzer doesn't find anything random 😄 