### PR TITLE
CI builds for Windows

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -32,9 +32,9 @@ steps:
     displayName: Retrieve pip cache
   - bash: |
       set -e -x
-      pip install --user --upgrade pip
-      pip install --user --upgrade pytest-azurepipelines
-      pip install --user .[dev]
+      python -m pip install --user --upgrade pip wheel setuptools
+      python -m pip install --user --upgrade pytest-azurepipelines
+      python -m pip install --user .[dev]
     name: install_cyclonedds_py
     displayName: Run installers
   - bash: |


### PR DESCRIPTION
The windows builds broke because something with pip changed on Azure Pipelines. This fixes that by switching the invocation to `python -m pip`.