### PR TITLE
Fix the reuse of typedefs (and sequence/array types).

### DIFF
--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import pytest
 
 import cyclonedds.internal
@@ -7,6 +8,7 @@ from cyclonedds.topic import Topic
 from cyclonedds.pub import DataWriter
 from cyclonedds.sub import DataReader
 from cyclonedds.util import duration
+from cyclonedds.idl import IdlStruct, types as pt
 
 from support_modules.test_fullxcdr2_classes import XBitmask, XEnum, XStruct, XUnion
 
@@ -65,3 +67,24 @@ def test_dynamic_publish_complex():
     wr.write(datatype(A=tmap['XUnion'](A=tmap['XEnum'].V1), k=1))
 
     assert rd.read()[0].k == 1
+
+
+def test_dynamic_repeated_typedef_array():
+    arrtype = pt.typedef["arrtype", pt.array[int, 2]]
+
+    @dataclass
+    class Foo(IdlStruct):
+        foo: arrtype
+        bar: arrtype
+
+    dp = DomainParticipant()
+    tp = Topic(dp, "DynTest", Foo)
+    rd = DataReader(dp, tp)
+
+    d, w = get_types_for_typeid(dp, Foo.__idl__.get_type_id(), duration(seconds=1))
+    tp2 = Topic(dp, "DynTest", d)
+    wr = DataWriter(dp, tp2)
+
+    wr.write(d([1,2], [1,2]))
+    assert rd.read()[0].foo[0] == 1
+


### PR DESCRIPTION
Fixes #85. Test that reproduces issue `test_dynamic_repeated_typedef_array` was added, fails with current release.