### PR TITLE
Add MANIFEST.in 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft buildhelp           # include the buildhelp package in the source distribution
+graft clayer              # include the C layer
+graft idlpy               # include the IDL python backend
+global-exclude *.py[cod]  # exclude python compiled bytecode files


### PR DESCRIPTION
Turns out the source distribution pushed to pypi is broken for all releases so far, since files used in building the package are not included by default. The MANIFEST.in file specifies which additional files need to go into the source distribution. This fixes issue #96 once we make another release. This should also be cherry-picked into the 0.9.x branch.