### PR TITLE
Add typebuilder tests

### DIFF
--- a/tests/support_modules/fuzz_tools/checks/typebuilder.py
+++ b/tests/support_modules/fuzz_tools/checks/typebuilder.py
@@ -1,0 +1,10 @@
+import traceback
+
+from ..rand_idl.context_containers import FullContext
+from ..utility.stream import Stream
+
+def check_sertype_from_typeobj(log: Stream, ctx: FullContext, typename: str) -> bool:
+    c_res = ctx.c_app.typebuilder(typename)
+    if not c_res[0]:
+        log << "typebuilder failed: " << c_res[1] << log.endl
+    return c_res[0]

--- a/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
+++ b/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
@@ -15,8 +15,14 @@
 #include <assert.h>
 #include <string.h>
 
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsrt/string.h"
 #include "dds/ddsi/ddsi_cdrstream.h"
 #include "dds/ddsi/ddsi_serdata_default.h"
+#include "dds/ddsi/ddsi_domaingv.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#include "dds/ddsi/ddsi_typebuilder.h"
+#include "dds/ddsi/ddsi_xt_impl.h"
 #include "dds/ddsc/dds_public_qosdefs.h"
 
 #include "xtypes_sub.h"
@@ -44,6 +50,176 @@ static void tohex(unsigned char * in, size_t insz, char * out, size_t outsz)
     out[loop*2] = '\0';
 }
 
+static void xcdr2_ser (const void * obj, const dds_topic_descriptor_t * desc, dds_ostream_t * os)
+{
+    struct ddsi_sertype_default sertype;
+    memset (&sertype, 0, sizeof (sertype));
+    sertype.type = (struct ddsi_sertype_default_desc) {
+        .size = desc->m_size,
+        .align = desc->m_align,
+        .flagset = desc->m_flagset,
+        .keys.nkeys = 0,
+        .keys.keys = NULL,
+        .ops.nops = dds_stream_countops (desc->m_ops, desc->m_nkeys, desc->m_keys),
+        .ops.ops = (uint32_t *) desc->m_ops
+    };
+
+    os->m_buffer = NULL;
+    os->m_index = 0;
+    os->m_size = 0;
+    os->m_xcdr_version = CDR_ENC_VERSION_2;
+    dds_stream_write_sampleLE ((dds_ostreamLE_t *) os, obj, &sertype);
+}
+
+static void xcdr2_deser(unsigned char * buf, uint32_t sz, void ** obj, const dds_topic_descriptor_t * desc)
+{
+    unsigned char * data;
+    uint32_t srcoff = 0;
+    dds_istream_t is = {.m_buffer = buf, .m_index = 0, .m_size = sz, .m_xcdr_version = CDR_ENC_VERSION_2};
+    *obj = ddsrt_calloc(1, desc->m_size);
+    dds_stream_read(&is, (void *)*obj, desc->m_ops);
+}
+
+static bool ti_to_pairs_equal (dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair * a, dds_sequence_DDS_XTypes_TypeIdentifierTypeObjectPair * b)
+{
+  if (a->_length != b->_length)
+    return false;
+  for (uint32_t n = 0; n < a->_length; n++)
+  {
+    struct DDS_XTypes_TypeObject *to_b = NULL;
+    uint32_t m;
+    for (m = 0; !to_b && m < b->_length; m++)
+    {
+      if (!ddsi_typeid_compare_impl (&a->_buffer[n].type_identifier, &b->_buffer[m].type_identifier))
+        to_b = &b->_buffer[m].type_object;
+    }
+    if (!to_b)
+      return false;
+
+    dds_ostream_t to_a_ser = { NULL, 0, 0, CDR_ENC_VERSION_2 };
+    xcdr2_ser (&a->_buffer[n].type_object, &DDS_XTypes_TypeObject_desc, &to_a_ser);
+    dds_ostream_t to_b_ser = { NULL, 0, 0, CDR_ENC_VERSION_2 };
+    xcdr2_ser (to_b, &DDS_XTypes_TypeObject_desc, &to_b_ser);
+
+    if (to_a_ser.m_index != to_b_ser.m_index)
+      return false;
+    if (memcmp (to_a_ser.m_buffer, to_b_ser.m_buffer, to_a_ser.m_index))
+      return false;
+
+    dds_ostream_fini (&to_a_ser);
+    dds_ostream_fini (&to_b_ser);
+  }
+  return true;
+}
+
+static bool ti_pairs_equal (dds_sequence_DDS_XTypes_TypeIdentifierPair * a, dds_sequence_DDS_XTypes_TypeIdentifierPair * b)
+{
+    if (a->_length != b->_length)
+    return false;
+  for (uint32_t n = 0; n < a->_length; n++)
+  {
+    bool found = false;
+    for (uint32_t m = 0; !found && m < b->_length; m++)
+    {
+      if (!ddsi_typeid_compare_impl (&a->_buffer[n].type_identifier1, &b->_buffer[m].type_identifier1))
+      {
+        if (ddsi_typeid_compare_impl (&a->_buffer[n].type_identifier2, &b->_buffer[m].type_identifier2))
+          return false;
+        found = true;
+      }
+    }
+    if (!found)
+      return false;
+  }
+  return true;
+}
+
+static bool tmap_equal (ddsi_typemap_t * a, ddsi_typemap_t * b)
+{
+  return ti_to_pairs_equal (&a->x.identifier_object_pair_minimal, &b->x.identifier_object_pair_minimal)
+      && ti_to_pairs_equal (&a->x.identifier_object_pair_complete, &b->x.identifier_object_pair_complete)
+      && ti_pairs_equal (&a->x.identifier_complete_minimal, &b->x.identifier_complete_minimal);
+}
+
+static bool topic_desc_eq (const dds_topic_descriptor_t * generated_desc, const dds_topic_descriptor_t * desc)
+{
+    printf("size: %u (%u)\n", generated_desc->m_size, desc->m_size);
+    if (desc->m_size != generated_desc->m_size)
+        return false;
+    printf("align: %u (%u)\n", generated_desc->m_align, desc->m_align);
+    if (desc->m_align != generated_desc->m_align)
+        return false;
+    printf("flagset: %x (%x)\n", generated_desc->m_flagset, desc->m_flagset);
+    if (desc->m_flagset != generated_desc->m_flagset)
+        return false;
+    printf("nkeys: %u (%u)\n", generated_desc->m_nkeys, desc->m_nkeys);
+    if (desc->m_nkeys != generated_desc->m_nkeys)
+        return false;
+    for (uint32_t n = 0; n < desc->m_nkeys; n++)
+    {
+        printf("key[%u] name: %s (%s)\n", n, generated_desc->m_keys[n].m_name, desc->m_keys[n].m_name);
+        if (strcmp(desc->m_keys[n].m_name, generated_desc->m_keys[n].m_name))
+            return false;
+        printf("  offset: %u (%u)\n", generated_desc->m_keys[n].m_offset, desc->m_keys[n].m_offset);
+        if (desc->m_keys[n].m_offset != generated_desc->m_keys[n].m_offset)
+            return false;
+        printf("  index: %u (%u)\n", generated_desc->m_keys[n].m_idx, desc->m_keys[n].m_idx);
+        if (desc->m_keys[n].m_idx != generated_desc->m_keys[n].m_idx)
+            return false;
+    }
+    printf("typename: %s (%s)\n", generated_desc->m_typename, desc->m_typename);
+    if (strcmp(desc->m_typename, generated_desc->m_typename))
+        return false;
+    printf("nops: %u (%u)\n", generated_desc->m_nops, desc->m_nops);
+    if (desc->m_nops != generated_desc->m_nops)
+        return false;
+
+    uint32_t ops_cnt_gen = dds_stream_countops(generated_desc->m_ops, generated_desc->m_nkeys, generated_desc->m_keys);
+    uint32_t ops_cnt = dds_stream_countops(desc->m_ops, desc->m_nkeys, desc->m_keys);
+    printf("ops count: %u (%u)\n", ops_cnt_gen, ops_cnt);
+    if (ops_cnt_gen != ops_cnt)
+        return false;
+    for (uint32_t n = 0; n < ops_cnt; n++)
+    {
+        if (desc->m_ops[n] != generated_desc->m_ops[n])
+        {
+            printf("incorrect op at index %u: 0x%08x (0x%08x)\n", n, generated_desc->m_ops[n], desc->m_ops[n]);
+            return false;
+        }
+    }
+
+    printf("typeinfo: %u (%u)\n", generated_desc->type_information.sz, desc->type_information.sz);
+    const struct ddsi_sertype_cdr_data tinfo_ser = {.sz = desc->type_information.sz, .data = desc->type_information.data};
+    ddsi_typeinfo_t *tinfo = ddsi_typeinfo_deser(&tinfo_ser);
+    const struct ddsi_sertype_cdr_data gen_tinfo_ser = {.sz = generated_desc->type_information.sz, .data = generated_desc->type_information.data};
+    ddsi_typeinfo_t *gen_tinfo = ddsi_typeinfo_deser(&gen_tinfo_ser);
+    if (!ddsi_typeinfo_equal(tinfo, gen_tinfo, DDSI_TYPE_INCLUDE_DEPS))
+    {
+        printf("typeinfo different\n");
+        return false;
+    }
+    ddsi_typeinfo_fini(tinfo);
+    ddsrt_free(tinfo);
+    ddsi_typeinfo_fini(gen_tinfo);
+    ddsrt_free(gen_tinfo);
+
+    printf("typemap: %u (%u)\n", generated_desc->type_mapping.sz, desc->type_mapping.sz);
+    const struct ddsi_sertype_cdr_data tmap_ser = {.sz = desc->type_mapping.sz, .data = desc->type_mapping.data};
+    ddsi_typemap_t *tmap = ddsi_typemap_deser(&tmap_ser);
+    const struct ddsi_sertype_cdr_data gen_tmap_ser = {.sz = generated_desc->type_mapping.sz, .data = generated_desc->type_mapping.data};
+    ddsi_typemap_t *gen_tmap = ddsi_typemap_deser(&gen_tmap_ser);
+    if (!tmap_equal(tmap, gen_tmap))
+    {
+        printf("typemap different\n");
+        return false;
+    }
+    ddsi_typemap_fini(tmap);
+    ddsrt_free(tmap);
+    ddsi_typemap_fini(gen_tmap);
+    ddsrt_free(gen_tmap);
+    return true;
+}
+
 // republisher topic
 int main(int argc, char **argv)
 {
@@ -60,8 +236,12 @@ int main(int argc, char **argv)
     char* hex_buff = NULL;
     size_t hex_buff_size = 0;
 
-    if(argc < 3) {
-        printf("Supply republishing type and sample amount.");
+    if (argc < 3)
+    {
+        printf("Supply republishing type and sample amount or test mode, e.g.:\n");
+        printf("  %s <typename> 10\n", argv[0]);
+        printf("  %s <typename> desc\n", argv[0]);
+        printf("  %s <typename> typebuilder\n", argv[0]);
         return 1;
     };
 
@@ -82,6 +262,41 @@ int main(int argc, char **argv)
         hex_buff = (char*) realloc(hex_buff, hex_buff_size);
         tohex(descriptor->type_mapping.data, descriptor->type_mapping.sz, hex_buff, hex_buff_size);
         printf("%s\n", hex_buff);
+        fflush(stdout);
+        return 0;
+    }
+    else if (strcmp(argv[2], "typebuilder") == 0)
+    {
+        struct ddsi_type *type;
+        participant = dds_create_participant(0, NULL, NULL);
+        if (participant < 0)
+            return 1;
+
+        topic = dds_create_topic(participant, descriptor, argv[1], NULL, NULL);
+        if (topic < 0)
+            return 1;
+
+        dds_typeinfo_t *type_info;
+        xcdr2_deser(descriptor->type_information.data, descriptor->type_information.sz, &type_info, &DDS_XTypes_TypeInformation_desc);
+
+        dds_topic_descriptor_t *generated_desc;
+        if (dds_create_topic_descriptor(DDS_FIND_SCOPE_LOCAL_DOMAIN, participant, type_info, DDS_SECS(0), &generated_desc))
+        {
+            printf("failed to create topic descriptor");
+            fflush(stdout);
+            return 1;
+        }
+
+        if (!topic_desc_eq(generated_desc, descriptor))
+            return 1;
+
+        dds_entity_t topic_gen = dds_create_topic(participant, generated_desc, "topic_gen", NULL, NULL);
+        if (topic_gen < 0)
+            return 1;
+
+        dds_delete_topic_descriptor (generated_desc);
+
+        printf("success");
         fflush(stdout);
         return 0;
     }

--- a/tests/support_modules/fuzz_tools/rand_idl/context_containers.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/context_containers.py
@@ -47,6 +47,22 @@ class CAppContext:
 
         return bytes.fromhex(hashes[0]), bytes.fromhex(hashes[1])
 
+    def typebuilder(self, typename: str) -> Tuple[bool, str]:
+        self.process = Popen([self.executable.name, typename, "typebuilder"], stderr=PIPE, stdout=PIPE)
+        try:
+            out, err = self.process.communicate(timeout=2)
+        except TimeoutExpired:
+            self.process.kill()
+            try:
+                out, err = self.process.communicate(timeout=2)
+                self.last_error = err.decode()
+            except:
+                self.last_error = "Did not manage to grab error output."
+            return -1
+        if self.process.returncode == 0:
+            return True, ""
+        return False, out.decode()
+
     def result(self) -> Optional[List[bytes]]:
         try:
             out, err = self.process.communicate(timeout=2)

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -10,6 +10,7 @@ from support_modules.fuzz_tools.utility.stream import Stream, FileStream
 from support_modules.fuzz_tools.checks.typeobject import check_type_object_equivalence
 from support_modules.fuzz_tools.checks.keys import check_py_c_key_equivalence, check_py_pyc_key_equivalence
 from support_modules.fuzz_tools.checks.mutated import check_mutation_assignability, check_mutation_key, check_enforced_non_communication
+from support_modules.fuzz_tools.checks.typebuilder import check_sertype_from_typeobj
 
 
 @pytest.mark.fuzzing
@@ -31,6 +32,7 @@ def test_fuzzing_types(fuzzing_config: FuzzingConfig):
         mut_success = True
         success &= check_type_object_equivalence(typelog, ctx, typename)
         success &= check_py_pyc_key_equivalence(typelog, ctx, typename, fuzzing_config.num_samples)
+        success &= check_sertype_from_typeobj(typelog, ctx, typename)
 
         if success:
             # If python and pyc are not agreeing on keys then python and C is not so relevant.


### PR DESCRIPTION
This adds tests for the Cyclone type object to topic descriptor conversion (introduced in [cyclonedds PR 1308](https://github.com/eclipse-cyclonedds/cyclonedds/pull/1308)) to the fuzzer test in the Python test suite. Purpose of this test is to check that for random types a topic descriptor created by IDLC is equal to a topic descriptor generated from the type's type object