### PR TITLE
__idlc__ must be invoked to print the shared library location

### DIFF
--- a/docs/source/idl.rst
+++ b/docs/source/idl.rst
@@ -14,7 +14,7 @@ You use the IDL compiler if you already have an idl file to define your types or
 
 .. code-block:: shell
 
-    idlc -l $(python -c "import cyclonedds.__idlc__") your_file.idl
+   idlc -l py your_file.idl
 
 
 .. _datatypes:


### PR DESCRIPTION
Importing __idlc__ has no side effects - it must be executed as __main__

If anyone has advice on how to fix this legal boilerplate let me know... I think I have signed everything - but then the bot is still complaining without a descriptive error afaict