### PR TITLE
Explain read/take DataReader's docstrings

### DIFF
--- a/cyclonedds/sub.py
+++ b/cyclonedds/sub.py
@@ -150,6 +150,10 @@ class DataReader(Entity, Generic[_T]):
         """Read a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples
         you are interested in.
 
+        Reading samples does not remove them from the :class:`DataReader's<DataReader>` receive queue. So read
+        methods may return the same sample in multiple calls. Your :class:`History<cyclonedds.qos.Policy.History>`
+        QoS Policy controls how "old" a sample can be whilst remaining in the queue.
+
         Parameters
         ----------
         N: int
@@ -182,6 +186,9 @@ class DataReader(Entity, Generic[_T]):
     def take(self, N: int = 1, condition: Entity = None, instance_handle: int = None) -> List[_T]:
         """Take a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples
         you are interested in.
+
+        Taking samples removes them from the :class:`DataReader's<DataReader>` receive queue. So take methods will
+        not return the same sample more than once.
 
         Parameters
         ----------


### PR DESCRIPTION
I'm not entirely sure my descriptions here are correct (knowledge from https://community.rti.com/static/documentation/connext-dds/5.2.0/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/AccessingData_Samples_ReadTake.htm via google).

I feel as though there are likely more QoS settings that affect the queue - I'd like to exhaustively list them here if you know where I can find what that list is?