### PR TITLE
Release pipeline source build fix

### DIFF
--- a/.azure/publish-release-nightly.yml
+++ b/.azure/publish-release-nightly.yml
@@ -64,4 +64,9 @@ jobs:
   - bash:
       find artifacts/ -name "*.whl" -exec mv {} wheelhouse \;
     displayName: Collect wheels for publication
+  - bash: |
+      cat setup.py | sed "s/package = \"[[:alnum:]]*\"/package = \"cyclonedds-nightly\"/g" > setup_temp.py
+      cat setup_temp.py | sed "s/__version__ = \"[[:digit:]]*\\.[[:digit:]]*\\.[[:digit:]]\"/__version__ = \"$(date '+%Y.%m.%d')\"/g" > setup.py
+      rm setup_temp.py
+    displayName: Write nightly version to setup.py
   - template: /.azure/templates/publish-package.yml


### PR DESCRIPTION
Well, it almost worked! Turns out the pipeline did not have permissions to push to "cyclonedds-nightly" so we have some permissions to add (will send those over @eboasson) but it did get permissions to push to the main package, which it promptly did with the source distribution which I forgot to update to say "cyclonedds-nightly". I've retracted the erronious release and I pushed the builds to PyPi-cyclonedds-nightly now manually so I can generate access tokens, this fix needs to be in before the next release can build (I've disabled the pipeline until then)