### PR TITLE
Some general doc string improvements

### DIFF
--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -1752,7 +1752,7 @@ class WaitSet(Entity):
         Parameters
         ----------
         timeout: int
-            The maximum number of nanoseconds to block. Use the function :func:`duration<cdds.util.duration>`
+            The maximum number of nanoseconds to block. Use the function :func:`duration<cyclonedds.util.duration>`
             to write that in a human readable format.
 
         Returns
@@ -1774,7 +1774,7 @@ class WaitSet(Entity):
         ----------
         abstime: int
             The absolute time in nanoseconds since the start of the program (TODO CONFIRM THIS)
-            to block. Use the function :func:`duration<cdds.util.duration>` to write that in
+            to block. Use the function :func:`duration<cyclonedds.util.duration>` to write that in
             a human readable format.
 
         Returns

--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -129,32 +129,32 @@ class Entity(DDS):
 
     Attributes
     ----------
-    subscriber:  Subscriber, optional
+    subscriber
                  If this entity is associated with a DataReader retrieve it.
                  It is read-only. This is a proxy for get_subscriber().
-    publisher:   Publisher, optional
+    publisher
                  If this entity is associated with a Publisher retrieve it.
                  It is read-only. This is a proxy for get_publisher().
-    datareader:  DataReader, optional
+    datareader
                  If this entity is associated with a DataReader retrieve it.
                  It is read-only. This is a proxy for get_datareader().
     guid:        uuid.UUID
                  Return the globally unique identifier for this entity.
                  It is read-only. This is a proxy for get_guid().
-    status_mask: int
+    status_mask
                  The status mask for this entity. It is a set of bits formed
                  from ``DDSStatus``. This is a proxy for get/set_status_mask().
-    parent:      Entity, optional
+    parent
                  The entity that is this entities parent. For example: the subscriber for a
                  datareader, the participant for a topic.
                  It is read-only. This is a proxy for get_parent().
-    participant: DomainParticipant, optional
+    participant
                  Get the participant for any entity, will only fail for a ``Domain``.
                  It is read-only. This is a proxy for get_participant().
-    children:    List[Entity]
+    children
                  Get a list of children belonging to this entity. It is the opposite as ``parent``.
                  It is read-only. This is a proxy for get_children().
-    domain_id:   int
+    domain_id
                  Get the id of the domain this entity belongs to.
     """
 
@@ -198,7 +198,7 @@ class Entity(DDS):
 
         Returns
         -------
-        Subscriber, optional
+        Optional[Subscriber]
             Not all entities are associated with a subscriber, so this method may return None.
 
         Raises
@@ -212,14 +212,14 @@ class Entity(DDS):
             ref, f"Occurred when getting the subscriber for {repr(self)}"
         )
 
-    subscriber: "cyclonedds.sub.Subscriber" = property(get_subscriber)
+    subscriber: Optional["cyclonedds.sub.Subscriber"] = property(get_subscriber)
 
     def get_publisher(self) -> Optional["cyclonedds.pub.Publisher"]:
         """Retrieve the publisher associated with this entity.
 
         Returns
         -------
-        Publisher, optional
+        Optional[Publisher]
             Not all entities are associated with a publisher, so this method may return None.
 
         Raises
@@ -231,14 +231,14 @@ class Entity(DDS):
             return self.get_entity(ref)
         raise DDSException(ref, f"Occurred when getting the publisher for {repr(self)}")
 
-    publisher: "cyclonedds.sub.Publisher" = property(get_publisher)
+    publisher: Optional["cyclonedds.pub.Publisher"] = property(get_publisher)
 
     def get_datareader(self) -> Optional["cyclonedds.sub.DataReader"]:
         """Retrieve the datareader associated with this entity.
 
         Returns
         -------
-        DataReader, optional
+        Optional[DataReader]
             Not all entities are associated with a datareader, so this method may return None.
 
         Raises
@@ -301,7 +301,7 @@ class Entity(DDS):
 
         Parameters
         ----------
-        mask : int, optional
+        mask
             The :class:`DDSStatus` mask. If not supplied the mask is used that was set on this Entity using set_status_mask.
 
         Returns
@@ -323,13 +323,13 @@ class Entity(DDS):
             return status.value
         raise DDSException(ret, f"Occurred when reading the status for {repr(self)}")
 
-    def take_status(self, mask=None) -> int:
+    def take_status(self, mask: int = None) -> int:
         """Take the status bits set on this Entity, after which they will be set to 0 again.
         You can build a mask by using :class:`DDSStatus`.
 
         Parameters
         ----------
-        mask : int, optional
+        mask
             The :class:`DDSStatus` mask. If not supplied the mask is used that was set on this Entity using set_status_mask.
 
         Returns
@@ -411,7 +411,7 @@ class Entity(DDS):
             ret, f"Occurred when setting the status mask for {repr(self)}"
         )
 
-    status_mask = property(get_status_mask, set_status_mask)
+    status_mask: int = property(get_status_mask, set_status_mask)
 
     def get_qos(self) -> Qos:
         """Get the :class:`Qos` associated with this entity. Note that the object returned is not
@@ -502,7 +502,7 @@ class Entity(DDS):
 
         Returns
         -------
-        Entity, optional
+        Optional[Entity]
             The parent of this entity. This would be the Subscriber for a DataReader, DomainParticipant for a Topic etc.
 
         Raises
@@ -519,14 +519,14 @@ class Entity(DDS):
 
         raise DDSException(ret, f"Occurred when getting the parent of {repr(self)}")
 
-    parent = property(get_parent)
+    parent: Optional["Entity"] = property(get_parent)
 
     def get_participant(self) -> Optional["cyclonedds.domain.DomainParticipant"]:
         """Get the domain participant for this entity. This should work on all valid Entity objects except a Domain.
 
         Returns
         -------
-        DomainParticipant, optional
+        Optional[cyclonedds.domain.DomainParticipant]
             Only fails for a Domain object.
 
         Raises
@@ -545,7 +545,7 @@ class Entity(DDS):
             ret, f"Occurred when getting the participant of {repr(self)}"
         )
 
-    participant = property(get_participant)
+    participant: Optional["cyclonedds.domain.DomainParticipant"] = property(get_participant)
 
     def get_children(self) -> List["Entity"]:
         """Get the list of children of this entity. For example, the list of datareaders belonging to a subscriber.
@@ -578,7 +578,7 @@ class Entity(DDS):
 
         raise DDSException(ret, f"Occurred when getting the children of {repr(self)}")
 
-    children = property(get_children)
+    children: List["Entity"] = property(get_children)
 
     def get_domain_id(self) -> int:
         """Get the id of the domain this entity resides in.
@@ -599,7 +599,7 @@ class Entity(DDS):
 
         raise DDSException(ret, f"Occurred when getting the domainid of {repr(self)}")
 
-    domain_id = property(get_domain_id)
+    domain_id: int = property(get_domain_id)
 
     def begin_coherent(self) -> None:
         """Begin coherent publishing or begin accessing a coherent set in a Subscriber.
@@ -1008,7 +1008,7 @@ class Listener(DDS):
 
     def on_liveliness_changed(
         self,
-        reader: "cyclonedds.pub.DataReader",
+        reader: "cyclonedds.sub.DataReader",
         status: dds_c_t.liveliness_changed_status,
     ) -> None:
         pass
@@ -1016,7 +1016,7 @@ class Listener(DDS):
     def set_on_liveliness_changed(
         self,
         callable: Callable[
-            ["cyclonedds.pub.DataReader", dds_c_t.liveliness_changed_status], None
+            ["cyclonedds.sub.DataReader", dds_c_t.liveliness_changed_status], None
         ],
     ):
         self.on_liveliness_changed = callable

--- a/cyclonedds/pub.py
+++ b/cyclonedds/pub.py
@@ -84,7 +84,8 @@ class Publisher(Entity):
         Parameters
         ----------
         timeout
-            The maximum number of nanoseconds to wait
+            The maximum number of nanoseconds to wait. Use the function :func:`duration<cyclonedds.util.duration>`
+            to write that in a human readable format.
         """
         ret = self._wait_for_acks(self._ref, timeout)
         if ret == 0:
@@ -311,7 +312,8 @@ class DataWriter(Entity, Generic[_T]):
         Parameters
         ----------
         timeout
-            The maximum number of nanoseconds to wait
+            The maximum number of nanoseconds to wait. Use the function :func:`duration<cyclonedds.util.duration>`
+            to write that in a human readable format.
         """
         ret = self._wait_for_acks(self._ref, timeout)
         if ret == 0:

--- a/cyclonedds/pub.py
+++ b/cyclonedds/pub.py
@@ -76,6 +76,16 @@ class Publisher(Entity):
         raise DDSException(ret, f"Occurred while resuming {repr(self)}")
 
     def wait_for_acks(self, timeout: int):
+        """
+        This operation blocks the calling thread until either all data written by the publisher
+        or writer is acknowledged by all matched reliable reader entities, or else the duration
+        specified by the timeout parameter elapses, whichever happens first.
+
+        Parameters
+        ----------
+        timeout
+            The maximum number of nanoseconds to wait
+        """
         ret = self._wait_for_acks(self._ref, timeout)
         if ret == 0:
             return True
@@ -158,6 +168,14 @@ class DataWriter(Entity, Generic[_T]):
         return self._topic
 
     def write(self, sample: _T, timestamp: Optional[int] = None):
+        """
+        Parameters
+        ----------
+        sample
+            The sample to write
+        timestamp
+            The sample's source_timestamp (in nanoseconds since the UNIX Epoch)
+        """
         if not isinstance(sample, self.data_type):
             raise TypeError(f"{sample} is not of type {self.data_type}")
 
@@ -173,6 +191,17 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while writing sample in {repr(self)}")
 
     def write_dispose(self, sample: _T, timestamp: Optional[int] = None):
+        """
+        Similar to :func:`write` but also marks the sample for disposal by setting its
+        :class:`InstanceState<cyclonedds.core.InstanceState>` to `NotAliveDisposed`.
+
+        Parameters
+        ----------
+        sample
+            The sample to dispose
+        timestamp
+            The sample's source_timestamp (in nanoseconds since the UNIX Epoch)
+        """
         ser = sample.serialize(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
@@ -185,6 +214,17 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while writedisposing sample in {repr(self)}")
 
     def dispose(self, sample: _T, timestamp: Optional[int] = None):
+        """
+        Marks the sample for disposal by setting its :class:`InstanceState<cyclonedds.core.InstanceState>` to
+        `NotAliveDisposed`.
+
+        Parameters
+        ----------
+        sample
+            The sample to dispose
+        timestamp
+            The sample's source_timestamp (in nanoseconds since the UNIX Epoch)
+        """
         ser = sample.serialize(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
@@ -197,6 +237,17 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while disposing in {repr(self)}")
 
     def dispose_instance_handle(self, handle: int, timestamp: Optional[int] = None):
+        """
+        Marks the instance and all samples associated wiht the given handle for disposal by setting their
+        :class:`InstanceState<cyclonedds.core.InstanceState>` to `NotAliveDisposed`.
+
+        Parameters
+        ----------
+        handle
+            An instance handle received from :func:`register_instance` or :func:`lookup_instance`.
+        timestamp
+            The instance's source_timestamp (in nanoseconds since the UNIX Epoch)
+        """
         if timestamp is not None:
             ret = ddspy_dispose_handle_ts(self._ref, handle, timestamp)
         else:
@@ -215,6 +266,14 @@ class DataWriter(Entity, Generic[_T]):
         return ret
 
     def unregister_instance(self, sample: _T, timestamp: Optional[int] = None):
+        """
+        Parameters
+        ----------
+        sample
+            The sample to unregister
+        timestamp
+            The timestamp used at registration (in nanoseconds since the UNIX Epoch)
+        """
         ser = sample.serialize(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
@@ -227,6 +286,14 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while unregistering instance in {repr(self)}")
 
     def unregister_instance_handle(self, handle: int, timestamp: Optional[int] = None):
+        """
+        Parameters
+        ----------
+        handle
+            An instance handle received from :func:`register_instance` or :func:`lookup_instance`.
+        timestamp
+            The timestamp used at registration (in nanoseconds since the UNIX Epoch)
+        """
         if timestamp is not None:
             ret = ddspy_unregister_instance_handle_ts(self._ref, handle, timestamp)
         else:
@@ -236,6 +303,16 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while unregistering instance handle n {repr(self)}")
 
     def wait_for_acks(self, timeout: int) -> bool:
+        """
+        This operation blocks the calling thread until either all data written by the publisher
+        or writer is acknowledged by all matched reliable reader entities, or else the duration
+        specified by the timeout parameter elapses, whichever happens first.
+
+        Parameters
+        ----------
+        timeout
+            The maximum number of nanoseconds to wait
+        """
         ret = self._wait_for_acks(self._ref, timeout)
         if ret == 0:
             return True
@@ -244,6 +321,9 @@ class DataWriter(Entity, Generic[_T]):
         raise DDSException(ret, f"Occurred while waiting for acks from {repr(self)}")
 
     def lookup_instance(self, sample: _T) -> Optional[int]:
+        """
+        This operation takes a sample and returns an instance handle to be used for subsequent operations.
+        """
         ser = sample.serialize(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 

--- a/cyclonedds/qos.py
+++ b/cyclonedds/qos.py
@@ -100,7 +100,7 @@ class Policy:
         Examples
         --------
         >>> Policy.History.KeepAll
-        >>> Policy.History.KeepLast(amount=10)
+        >>> Policy.History.KeepLast(depth=10)
 
         Attributes
         ----------

--- a/cyclonedds/qos.py
+++ b/cyclonedds/qos.py
@@ -70,7 +70,7 @@ class Policy:
             ----------
             max_blocking_time : int
                 The number of nanoseconds the writer will bock when its history is full.
-                Use the :func:`duration<cdds.util.duration>` function to avoid time calculation headaches.
+                Use the :func:`duration<cyclonedds.util.duration>` function to avoid time calculation headaches.
 
             """
             __scope__: ClassVar[str] = "Reliability"
@@ -308,7 +308,7 @@ class Policy:
             Attributes
             ----------
             lease_duration: int
-                The lease duration in nanoseconds. Use the helper function :func:`duration<cdds.util.duration>` to write
+                The lease duration in nanoseconds. Use the helper function :func:`duration<cyclonedds.util.duration>` to write
                 the duration in a human readable format.
             """
             __scope__: ClassVar[str] = "Liveliness"
@@ -321,7 +321,7 @@ class Policy:
             Attributes
             ----------
             lease_duration: int
-                The lease duration in nanoseconds. Use the helper function :func:`duration<cdds.util.duration>` to write
+                The lease duration in nanoseconds. Use the helper function :func:`duration<cyclonedds.util.duration>` to write
                 the duration in a human readable format.
             """
             __scope__: ClassVar[str] = "Liveliness"
@@ -334,7 +334,7 @@ class Policy:
             Attributes
             ----------
             lease_duration: int
-                The lease duration in nanoseconds. Use the helper function :func:`duration<cdds.util.duration>` to write
+                The lease duration in nanoseconds. Use the helper function :func:`duration<cyclonedds.util.duration>` to write
                 the duration in a human readable format.
             """
             __scope__: ClassVar[str] = "Liveliness"
@@ -351,7 +351,7 @@ class Policy:
         Attributes
         ----------
         filter_time: int
-            Minimum time between samples in nanoseconds.  Use the helper function :func:`duration<cdds.util.duration>`
+            Minimum time between samples in nanoseconds.  Use the helper function :func:`duration<cyclonedds.util.duration>`
             to write the duration in a human readable format.
         """
         __scope__: ClassVar[str] = "TimeBasedFilter"

--- a/cyclonedds/sub.py
+++ b/cyclonedds/sub.py
@@ -150,6 +150,9 @@ class DataReader(Entity, Generic[_T]):
         """Read a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples
         you are interested in.
 
+        Reading samples does not remove them from the :class:`DataReader's<DataReader>` receive queue. So read
+        methods may return the same sample in multiple calls.
+
         Parameters
         ----------
         N: int
@@ -182,6 +185,9 @@ class DataReader(Entity, Generic[_T]):
     def take(self, N: int = 1, condition: Entity = None, instance_handle: int = None) -> List[_T]:
         """Take a maximum of N samples, non-blocking. Optionally use a read/query-condition to select which samples
         you are interested in.
+
+        Taking samples removes them from the :class:`DataReader's<DataReader>` receive queue. So take methods will
+        not return the same sample more than once.
 
         Parameters
         ----------

--- a/cyclonedds/util.py
+++ b/cyclonedds/util.py
@@ -16,7 +16,7 @@ from .internal import dds_infinity
 
 
 def isgoodentity(v: object) -> bool:
-    """Helper function that checks to see if an object is a valid :class:`Entity<cdds.core.entity.Entity>` returned from DDS.
+    """Helper function that checks to see if an object is a valid :class:`Entity<cyclonedds.core.Entity>` returned from DDS.
     This function will never raise an exception.
 
     Parameters
@@ -27,7 +27,7 @@ def isgoodentity(v: object) -> bool:
     Returns
     -------
     bool
-        Whether this entity is a valid :class:`Entity<cdds.core.entity.Entity>`.
+        Whether this entity is a valid :class:`Entity<cyclonedds.core.Entity>`.
     """
     return \
         v is not None and \
@@ -80,4 +80,13 @@ def duration(*, weeks: float = 0, days: float = 0, hours: float = 0, minutes: fl
 class timestamp:
     @staticmethod
     def now():
+        """
+        In DDS timestamps are typically expressed as nanoseconds since the Unix Epoch (dds_time_t). This helper function
+        returns the current time in nanoseconds.
+
+        Returns
+        -------
+        int
+            Number of nanoseconds since the Unix Epoch.
+        """
         return _time_ns()

--- a/docs/source/cyclonedds.dynamic.rst
+++ b/docs/source/cyclonedds.dynamic.rst
@@ -3,4 +3,4 @@ dynamic
 
 .. autofunction:: cyclonedds.dynamic.get_types_for_typeid
 
-.. autofunction:: cyclonedds.dynamic.get_types_for_typeid
+.. autofunction:: cyclonedds.dynamic.async_get_types_for_typeid

--- a/docs/source/cyclonedds.util.rst
+++ b/docs/source/cyclonedds.util.rst
@@ -8,4 +8,4 @@ The util module contains some utility functions that have no good place elsewher
 
 .. autofunction:: cyclonedds.util.duration
 
-.. autoclass:: cyclonedds.util.timestamp
+.. autofunction:: cyclonedds.util.timestamp.now

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -93,7 +93,7 @@ Now to send our message over DDS we need to perform a few steps:
     from cyclonedds.pub import DataWriter
 
     participant = DomainParticipant()
-    topic = Topic(participant, Message, "Announcements")
+    topic = Topic(participant, "Announcements", Message)
     writer = DataWriter(participant, topic)
 
     writer.write(message)
@@ -115,7 +115,7 @@ Hurray, we have published are first message! However, it is hard to tell if that
         text: str
 
     participant = DomainParticipant()
-    topic = Topic(participant, Message, "Announcements")
+    topic = Topic(participant, "Announcements", Message)
     reader = DataReader(participant, topic)
 
     # If we don't receive a single announcement for five minutes we want the script to exit.


### PR DESCRIPTION
* Added some docs to DataWriter
* Added subset of #113 to DataReader
* Generally tried to improve annotations about timestamps
* Entity links & types fixed to reduce sphinx complaints

Worth asking if you're on board with trying to delegate to type hints (and type-hint syntax) in the docs as much as possible? Seems to me it'll be easier to keep in sync - however for the life of me I can't figure out how to annotate the return type with a description and still have sphinx pull the annotation from the function. So return types are still duplicated in the docstrings sadly.