### PR TITLE
Add missing _set_on_data_on_readers method to Listener

### DIFF
--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -1329,6 +1329,12 @@ class Listener(DDS):
     ) -> None:
         pass
 
+    @c_call("dds_lset_data_on_readers")
+    def _set_on_data_on_readers(
+        self, listener: dds_c_t.listener_p, callback: _data_on_readers_fn
+    ) -> None:
+        pass
+
     @c_call("dds_lset_sample_lost")
     def _set_on_sample_lost(
         self, listener: dds_c_t.listener_p, callback: _on_sample_lost_fn

--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -936,6 +936,10 @@ class Listener(DDS):
             listener.setters[name](functor)
 
     def merge(self, listener: "Listener") -> None:
+        """
+        Copies any configured (non-default) callbacks from the given `listener` to self, replacing existing callbacks
+        already configured on this listener.
+        """
         listener.copy_to(self)
 
     def on_inconsistent_topic(

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -289,3 +289,43 @@ def test_pub_matched_cross_participant(hitpoint_factory):
     assert datawriter_listener.hitpoint_data_available.was_not_hit()
 
     assert datareader_listener.hitpoint_pub_matched.was_not_hit()
+
+def test_listener_assignment_exhaustively():
+    evt_names = [
+        "on_data_available",
+        "on_inconsistent_topic",
+        "on_liveliness_lost",
+        "on_liveliness_changed",
+        "on_offered_deadline_missed",
+        "on_offered_incompatible_qos",
+        "on_data_on_readers",
+        "on_sample_lost",
+        "on_sample_rejected",
+        "on_requested_deadline_missed",
+        "on_requested_incompatible_qos",
+        "on_publication_matched",
+        "on_subscription_matched",
+    ]
+
+    funcs = {}
+    for n in evt_names:
+        def handler(*args, **kwargs):
+            print(*args, **kwargs)
+        funcs[n] = handler
+
+    # Check keyword arguments assign to the Listener instance
+    l = Listener(**funcs)
+    for n in evt_names:
+        assert getattr(l, n) is funcs[n]
+
+    # Check the set_on functions assign to the listener instance
+    funcs2 = {}
+    for n in evt_names:
+        def handler2(*args, **kwargs):
+            print(*args, **kwargs)
+        funcs2[n] = handler2
+        getattr(l, f"set_{n}")(handler2)
+
+    for n in evt_names:
+        assert getattr(l, n) is not funcs[n]
+        assert getattr(l, n) is funcs2[n]


### PR DESCRIPTION
I should probably write a test for this... but opening MR now whilst I have it done

Noticed when using this:
```python
from cyclonedds.core import Listener

def make_print_listener(name, listener=None):
    def printer(evt_name):
        def fn(*args, **kwargs):
            arg_string = ", ".join(repr(a) for a in args)
            if args and kwargs:
                arg_string += ", "
            arg_string += ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
            print(f"{name!r}.{evt_name}({arg_string})")
        return fn

    l = Listener(
        on_data_available=printer("on_data_available"),
        on_inconsistent_topic=printer("on_inconsistent_topic"),
        on_liveliness_lost=printer("on_liveliness_lost"),
        on_liveliness_changed=printer("on_liveliness_changed"),
        on_offered_deadline_missed=printer("on_offered_deadline_missed"),
        on_offered_incompatible_qos=printer("on_offered_incompatible_qos"),
        on_data_on_readers=printer("on_data_on_readers"),
        on_sample_lost=printer("on_sample_lost"),
        on_sample_rejected=printer("on_sample_rejected"),
        on_requested_deadline_missed=printer("on_requested_deadline_missed"),
        on_requested_incompatible_qos=printer("on_requested_incompatible_qos"),
        on_publication_matched=printer("on_publication_matched"),
        on_subscription_matched=printer("on_subscription_matched"),
    )
    if listener:
        l.merge(listener)
    return l

```