### PR TITLE
Fixes for circular dependencies preventing Entity destruction, and Listener re/un-assignment

### DIFF
--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -187,10 +187,10 @@ class Entity(DDS):
         self._listener = listener
 
     def __del__(self) -> None:
-        if not hasattr(self, "_ref") or self._ref not in self._entities:
+        if not hasattr(self, "_ref"):
             return
 
-        del self._entities[self._ref]
+        self._entities.pop(self._ref, None)
         self._delete(self._ref)
 
     def get_subscriber(self) -> Optional["cyclonedds.sub.Subscriber"]:

--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -474,23 +474,33 @@ class Entity(DDS):
         """
         return self._listener.copy() if self._listener else Listener()
 
-    def set_listener(self, listener: "Listener") -> None:
+    def set_listener(self, listener: Optional["Listener"]) -> None:
         """Update the listener for this object. If a listener already exist for this object only the fields you explicitly
-        have set on your new listener are overwritten.
+        have set on your new listener are overwritten. Passing None will remove this entity's Listener.
+
+        Future changes to the passed Listener object will not affect the Listener associated with this Entity.
 
         Parameters
         ----------
-        listener : Listener
-            The listener object to use.
+        listener :
+            The listener object to use, or None to remove the current listener from this Entity.
 
         Raises
         ------
         DDSException
         """
-        if self._listener != listener:
-            listener.copy_to(self._listener)
+        if listener is not None:
+            if self._listener is not None:
+                if self._listener != listener:
+                    listener.copy_to(self._listener)
+            else:
+                self._listener = listener.copy()
+            ref = self._listener._ref
+        else:
+            ref = None
+            self._listener = None
 
-        ret = self._set_listener(self._ref, listener._ref)
+        ret = self._set_listener(self._ref, ref)
         if ret == 0:
             return
         raise DDSException(ret, f"Occurred when setting the Listener for {repr(self)}")


### PR DESCRIPTION
After discussion here: https://discord.com/channels/960814229844291604/960836994500538408/1008760990525030420 and the demonstration here: https://gist.github.com/willstott101/8544a7c966b0788ff4f93da410e9fea7 it became clear that the presence of an Entity cannot be guaranteed to be present in the `_entities` `WeakRefDictionary` during finalization.

It was also useful whilst testing to be able to un-assign a DataReader's listener, so this MR comes with those changes too (including tests).

I can try and come up with a circular reference test if you like? Not entirely sure how I'll do that though. Maybe would be easy with `isgoodentity`