### PR TITLE
Maybe fix the hang in CI?

### DIFF
--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -190,8 +190,12 @@ class Entity(DDS):
         if not hasattr(self, "_ref"):
             return
 
-        self._entities.pop(self._ref, None)
-        self._delete(self._ref)
+        try:
+            del self._entities[self._ref]
+        except KeyError:
+            pass
+        else:
+            self._delete(self._ref)
 
     def get_subscriber(self) -> Optional["cyclonedds.sub.Subscriber"]:
         """Retrieve the subscriber associated with this entity.


### PR DESCRIPTION
From my testing the hang seems to be during cyclonedds Entity deletion. I think it must be related to freeing twice as this MR helps.

However I haven't confirmed this is what's happening, so not really that happy with this.

In other news my wider application test suite now segfaults with this change :) So we still have some way to go. It's up to you if you'd rather back out of the circular reference support at all until I've figured this out...