### PR TITLE
Revert "Don't rely on the _entities dictionary in the Entity finalizer."

### DIFF
--- a/cyclonedds/core.py
+++ b/cyclonedds/core.py
@@ -187,10 +187,10 @@ class Entity(DDS):
         self._listener = listener
 
     def __del__(self) -> None:
-        if not hasattr(self, "_ref"):
+        if not hasattr(self, "_ref") or self._ref not in self._entities:
             return
 
-        self._entities.pop(self._ref, None)
+        del self._entities[self._ref]
         self._delete(self._ref)
 
     def get_subscriber(self) -> Optional["cyclonedds.sub.Subscriber"]:


### PR DESCRIPTION
This reverts commit 54b90025c2f0c1b8d95a8acd10c9581f00b5aa3e - which isn't technically in this repo but :shrug: