### PR TITLE
WIP: Remove circular references from DataReaders

### DIFF
--- a/cyclonedds/builtin.py
+++ b/cyclonedds/builtin.py
@@ -157,7 +157,7 @@ class BuiltinDataReader(DataReader):
             ),
             listener=listener
         )
-        self._next_condition = ReadCondition(self, ViewState.Any | SampleState.NotRead | InstanceState.Any)
+        self._next_condition_states = ViewState.Any | SampleState.NotRead | InstanceState.Any
         if cqos:
             _CQos.cqos_destroy(cqos)
         self._make_constructors()

--- a/cyclonedds/sub.py
+++ b/cyclonedds/sub.py
@@ -140,8 +140,8 @@ class DataReader(Entity, Generic[_T]):
                 _CQos.cqos_destroy(cqos)
         self._topic = topic
         self._topic_ref = topic._ref
-        self._next_condition = None
-        self._keepalive_entities = [self.subscriber, topic]
+        self._next_condition_states = ViewState.Any | SampleState.NotRead | InstanceState.Alive
+        self._keepalive_entities = [self.subscriber]
 
     @property
     def topic(self) -> Topic[_T]:
@@ -227,9 +227,7 @@ class DataReader(Entity, Generic[_T]):
         DDSException
             If any error code is returned by the DDS API it is converted into an exception.
         """
-        self._next_condition = self._next_condition or \
-            ReadCondition(self, ViewState.Any | SampleState.NotRead | InstanceState.Alive)
-        samples = self.read(condition=self._next_condition)
+        samples = self.read(condition=ReadCondition(self, self._next_condition_states))
         if samples:
             return samples[0]
         return None
@@ -242,9 +240,7 @@ class DataReader(Entity, Generic[_T]):
         DDSException
             If any error code is returned by the DDS API it is converted into an exception.
         """
-        self._next_condition = self._next_condition or \
-            ReadCondition(self, ViewState.Any | SampleState.NotRead | InstanceState.Alive)
-        samples = self.take(condition=self._next_condition)
+        samples = self.take(condition=ReadCondition(self, self._next_condition_states))
         if samples:
             return samples[0]
         return None


### PR DESCRIPTION
Ok so if we're currently unable to support circular references (read: correct object finalization during the circular island collection phase in cpython where collection order is unspecified) then we need to not create reference cycles in the library ourselves at the very least.

The only case of this I've found specifically is `ReadCondition`s - I wonder if they really need to keep the reference to the `DataReader`? For now in this MR I've just made ReadConditions only exist for function scopes - which fixes the segfaults and hangs I've been seeing once removing all circular references from my own code.

Avoiding circular references is good practice anyway, really - but it is a shame the results are so explosive when they exist as they're so easy to introduce. In our case we want to expose users to a python API using cyclonedds so just avoiding them in app code is untenable.

I suspect it's actually a `cyclonedds` C bug that was causing the CI hanging - if `dds_delete` is meant to be idempotent and support any destruction order.

FWIW I found them quite manually by adding prints to Entity.__del__ for objects not found in the _entities dict.