### PR TITLE
Release GIL when creating topics

### DIFF
--- a/clayer/pysertype.c
+++ b/clayer/pysertype.c
@@ -975,7 +975,9 @@ ddspy_topic_create(PyObject *self, PyObject *args)
 
     if (sertype == NULL) return NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     sts = dds_create_topic_sertype(participant, name, (struct ddsi_sertype **) &sertype, qos, listener, NULL);
+    Py_END_ALLOW_THREADS
 
     if (PyErr_Occurred() || sts < 0) {
         ddsi_sertype_unref((struct ddsi_sertype *) sertype);


### PR DESCRIPTION
Fixes (at least 1 of) the deadlocks discussed in #134

It doesn't fix the deadlock triggered by https://github.com/eclipse-cyclonedds/cyclonedds-python/commit/54b90025c2f0c1b8d95a8acd10c9581f00b5aa3e sadly, so circular references still can't be supported.