### PR TITLE
force to run with python3

### DIFF
--- a/local-ci.py
+++ b/local-ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  * Copyright(c) 2021 ZettaScale Technology and others
  *


### PR DESCRIPTION
When trying to create a package with cpack on a red hat based system i get the following error

*** ERROR: ambiguous python shebang in local-ci.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.

as the python api needs python 3 a change from python to python3 will fix this error.