### PR TITLE
Emit raw string for generated `library_path`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if "BUILDING_SDIST" not in os.environ:
 
     with open(this_directory / 'cyclonedds' / '__library__.py', "w", encoding='utf-8') as f:
         f.write("in_wheel = False\n")
-        f.write(f"library_path = '{cyclone.ddsc_library}'")
+        f.write(f"library_path = r'{cyclone.ddsc_library}'")
 
 
     ext_modules = [


### PR DESCRIPTION
This prevents issues under Windows where the generated path may contain a `\U` which begins a unicode escape sequence. Emitting a raw string prevents those sequence from being interpreted in the generated `__library__.py` module.

Closes #145