### PR TITLE
Change how union equality is determined

### DIFF
--- a/cyclonedds/idl/__init__.py
+++ b/cyclonedds/idl/__init__.py
@@ -149,10 +149,7 @@ class IdlUnion(metaclass=IdlUnionMeta):
         if self.__class__ != other.__class__:
             return False
         if self.discriminator != other.discriminator:
-            if self.discriminator is None and other.discriminator != self.__idl_default_discriminator__:
-                return False
-            if other.discriminator is None and self.discriminator != self.__idl_default_discriminator__:
-                return False
+            return False
         if self.value != other.value:
             return False
         return True

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,0 +1,14 @@
+from cyclonedds.idl import IdlUnion, types
+
+
+class A(IdlUnion, discriminator=types.uint8):
+    f1: types.case[1, types.uint8]
+    f2: types.default[types.uint16]
+
+
+def test_union_not_equal():
+    # Even though these both map to the default case
+    # The very "thoughtful" XTypes API maps these to type kinds without case
+    # Which is very nice...
+    assert A(discriminator=3, value=1) != A(discriminator=2, value=1)
+


### PR DESCRIPTION
XTypes specifies the following:

_Two types are equivalent according to the Minimal equivalence relation if and only if either
they have equal Fully-Descriptive TypeIdentifiers, or else they have equal Minimal TypeIdentifiers._

I happily checked `is_fully_descriptive(typeid1) and typeid1 == typeid2` where typeid1 are `TypeIdentifier`s. These are `IdlUnion` in python. However, for primitive type kinds the discriminator is set to an *unmapped* discriminator, falling back to the default case, which it doesnt have, so it contains "nothing/void".

Now my "clever" code for union equality assumed that two unions both in the default case with equal value were equal. Clearly that cannot be the case, I simply was not as clever as the XTypes spec in coming up with the idea of using unmapped labels for unions for something else, silly me!

The new behaviour is that two discriminator values always result in non-equality. This can bite someone when they use `None` and `0` for a discriminator interchangeably but that is the cost of following the XTypes spec.