### PR TITLE
Reserved Python keywords support (Issue 105)

### DIFF
--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -974,9 +974,19 @@ class XTBuilder:
 
     @classmethod
     def _xt_complete_struct_member(cls, entity: Type[IdlStruct], name: str, _type: type) -> xt.CompleteStructMember:
+        #Reserved Python keywords support (Issue 105)
+        realName=name
+        if (name in get_idl_field_annotations(entity)):
+            if ("name" in get_idl_field_annotations(entity)[name]):
+                realName=get_idl_field_annotations(entity)[name]["name"]
+
+        #######################
+
         return xt.CompleteStructMember(
             common=cls._xt_common_struct_member(entity, name, _type, False),
-            detail=cls._xt_complete_member_detail(entity, name, _type)
+            #Reserved Python keywords support (Issue 105):
+            detail=cls._xt_complete_member_detail(entity, realName, _type)
+            #######################
         )
 
     @classmethod

--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -974,12 +974,9 @@ class XTBuilder:
 
     @classmethod
     def _xt_complete_struct_member(cls, entity: Type[IdlStruct], name: str, _type: type) -> xt.CompleteStructMember:
-        #Reserved Python keywords support (Issue 105)
-        realName=name
-        if (name in get_idl_field_annotations(entity)):
-            if ("name" in get_idl_field_annotations(entity)[name]):
-                realName=get_idl_field_annotations(entity)[name]["name"]
-
+        # Reserved Python keywords support (#105)
+        annotations = get_idl_field_annotations(entity).get(name)
+        realName = annotations["name"] if annotations and "name" in annotations else name
         #######################
 
         return xt.CompleteStructMember(

--- a/cyclonedds/idl/annotations.py
+++ b/cyclonedds/idl/annotations.py
@@ -59,6 +59,9 @@ def position(apply_to: str, value: int) -> None:
 def member_id(apply_to: str, value: int) -> None:
     __field_annotate(apply_to, "id", value)
 
+#Reserved Python keywords support (Issue 105):
+def member_name(apply_to: str, name: str) -> None:
+    __field_annotate(apply_to, "name", name)
 
 def member_hash_id(apply_to: str, value: Optional[str] = None) -> None:
     __field_annotate(apply_to, "hash_id", value)

--- a/idlpy/src/context.c
+++ b/idlpy/src/context.c
@@ -36,6 +36,10 @@
 #include <sys/stat.h>
 #endif
 
+//Reserved Python keywords support (Issue 105)
+#include "types.h"
+/////////////
+
 /// * IDL context * ///
 typedef struct idlpy_module_ctx_s *idlpy_module_ctx;
 
@@ -530,7 +534,16 @@ static idl_retcode_t write_module_headers(FILE *fh, idlpy_ctx octx, idlpy_module
         idl_fprintf(fh, fmt_entities, entity_prefix, octx->idl_file);
 
         for(int i = 0; i < idlpy_ssos_size(ctx->this_idl_file->entities); ++i) {
-            idl_fprintf(fh, fmt_entity, i > 0 ? ", " : "", idlpy_ssos_at(ctx->this_idl_file->entities, i));
+
+           //Reserved Python keywords support (Issue 105)
+            const char *name = idlpy_ssos_at(ctx->this_idl_file->entities, i);
+            const char *nameModified=get_c_name(name);
+            if (nameModified)
+                name = nameModified;
+            
+            idl_fprintf(fh, fmt_entity, i > 0 ? ", " : "", name);
+            
+            ///////////////////////////
         }
         idl_fprintf(fh, "\n");
     }
@@ -551,7 +564,15 @@ static idl_retcode_t write_module_headers(FILE *fh, idlpy_ctx octx, idlpy_module
 
     if (idlpy_ssos_size(ctx->this_idl_file->entities) > 0) {
         for(int i = 0; i < idlpy_ssos_size(ctx->this_idl_file->entities); ++i) {
-            idl_fprintf(fh, "\"%s\", ", idlpy_ssos_at(ctx->this_idl_file->entities, i));
+
+            //Reserved Python keywords support (Issue 105)
+            const char *name = idlpy_ssos_at(ctx->this_idl_file->entities, i);
+            const char *nameModified=get_c_name(name);
+            if (nameModified)
+                name = nameModified;
+            
+            idl_fprintf(fh, "\"%s\", ", name);
+            ///////////////////////////
         }
     }
 

--- a/idlpy/src/context.c
+++ b/idlpy/src/context.c
@@ -37,7 +37,7 @@
 #endif
 
 //Reserved Python keywords support (Issue 105)
-#include "types.h"
+#include "naming.h"
 /////////////
 
 /// * IDL context * ///
@@ -536,13 +536,8 @@ static idl_retcode_t write_module_headers(FILE *fh, idlpy_ctx octx, idlpy_module
         for(int i = 0; i < idlpy_ssos_size(ctx->this_idl_file->entities); ++i) {
 
            //Reserved Python keywords support (Issue 105)
-            const char *name = idlpy_ssos_at(ctx->this_idl_file->entities, i);
-            const char *nameModified=get_c_name(name);
-            if (nameModified)
-                name = nameModified;
-            
+            const char *name = filter_python_keywords(idlpy_ssos_at(ctx->this_idl_file->entities, i));
             idl_fprintf(fh, fmt_entity, i > 0 ? ", " : "", name);
-            
             ///////////////////////////
         }
         idl_fprintf(fh, "\n");
@@ -566,11 +561,7 @@ static idl_retcode_t write_module_headers(FILE *fh, idlpy_ctx octx, idlpy_module
         for(int i = 0; i < idlpy_ssos_size(ctx->this_idl_file->entities); ++i) {
 
             //Reserved Python keywords support (Issue 105)
-            const char *name = idlpy_ssos_at(ctx->this_idl_file->entities, i);
-            const char *nameModified=get_c_name(name);
-            if (nameModified)
-                name = nameModified;
-            
+            const char *name = filter_python_keywords(idlpy_ssos_at(ctx->this_idl_file->entities, i));
             idl_fprintf(fh, "\"%s\", ", name);
             ///////////////////////////
         }

--- a/idlpy/src/naming.c
+++ b/idlpy/src/naming.c
@@ -25,6 +25,11 @@
 #include "idl/version.h"
 #include "idl/processor.h"
 
+//Reserved Python keywords support (Issue 105)
+#include "types.h"
+/////////////
+
+
 
 static char *typename_of_type(idlpy_ctx ctx, idl_type_t type)
 {
@@ -213,9 +218,17 @@ char *absolute_name(idlpy_ctx ctx, const void *node)
             continue;
         ident = idl_identifier(root);
         assert(ident);
-        len += strlen(sep) + strlen(ident);
+        
+        //Reserved Python keywords support (Issue 105)
+        const char *name = ident;
+        const char *nameModified=get_c_name(ident);
+        if (nameModified)
+            name = nameModified;
+
+        len += strlen(sep) + strlen(name);
         if (root != ((idl_node_t*) node))
-            parnamelen += strlen(sep) + strlen(ident);
+            parnamelen += strlen(sep) + strlen(name);
+        /////////////////////
         sep = separator;
     }
 
@@ -236,16 +249,26 @@ char *absolute_name(idlpy_ctx ctx, const void *node)
 
         ident = idl_identifier(root);
         assert(ident);
-        cnt = strlen(ident);
+
+        //Reserved Python keywords support (Issue 105)
+        const char *name = ident;
+        const char *nameModified=get_c_name(ident);
+        if (nameModified) 
+            name = nameModified;
+
+        cnt = strlen(name);
         assert(cnt <= len);
         len -= cnt;
-        memmove(str + pyrootlen + len + 1, ident, cnt);
+        memmove(str + pyrootlen + len + 1, name, cnt);
+
         if (len == 0)
             break;
+
         cnt = strlen(sep);
         assert(cnt <= len);
         len -= cnt;
         memmove(str + pyrootlen + len + 1, sep, cnt);
+        /////////////////////
     }
     assert(len == 0);
 
@@ -273,7 +296,16 @@ char *idl_full_typename(const void *node)
             continue;
         ident = idl_identifier(root);
         assert(ident);
-        len += strlen(sep) + strlen(ident);
+        
+        //Reserved Python keywords support (Issue 105)
+        const char *name = ident;
+        const char *nameModified=get_c_name(ident);
+        if (nameModified) 
+            name = nameModified;
+        
+        len += strlen(sep) + strlen(name);
+        /////////////////////
+        
         sep = separator;
     }
 
@@ -291,16 +323,24 @@ char *idl_full_typename(const void *node)
 
         ident = idl_identifier(root);
         assert(ident);
-        cnt = strlen(ident);
+
+        //Reserved Python keywords support (Issue 105)
+        const char *name = ident;
+        const char *nameModified=get_c_name(ident);
+        if (nameModified)
+            name = nameModified;
+
+        cnt = strlen(name);
         assert(cnt <= len);
         len -= cnt;
-        memmove(str + len, ident, cnt);
+        memmove(str + len, name, cnt);
         if (len == 0)
             break;
         cnt = strlen(sep);
         assert(cnt <= len);
         len -= cnt;
         memmove(str + len, sep, cnt);
+        ////////////////////////////////
     }
     assert(len == 0);
     return str;

--- a/idlpy/src/naming.h
+++ b/idlpy/src/naming.h
@@ -19,5 +19,9 @@ char* typename_unwrap_typedef(idlpy_ctx ctx, const void *node);
 char* absolute_name(idlpy_ctx ctx, const void *node);
 char* idl_full_typename(const void *node);
 
+//Reserved Python keywords support (Issue 105)
+const char *filter_python_keywords(const char *name);
+const char *idlpy_identifier(const void *node);
+//////////////
 
 #endif //IDLPY_NAMING_H

--- a/idlpy/src/types.h
+++ b/idlpy/src/types.h
@@ -17,8 +17,4 @@
 
 idl_retcode_t generate_types(const idl_pstate_t *pstate, idlpy_ctx ctx);
 
-//Reserved Python keywords support (Issue 105)
-const char *get_c_name(const char *name);
-//////////////
-
 #endif

--- a/idlpy/src/types.h
+++ b/idlpy/src/types.h
@@ -17,4 +17,8 @@
 
 idl_retcode_t generate_types(const idl_pstate_t *pstate, idlpy_ctx ctx);
 
+//Reserved Python keywords support (Issue 105)
+const char *get_c_name(const char *name);
+//////////////
+
 #endif


### PR DESCRIPTION
We (@Bit-Seq, @jordialexalar and me) have implemented a solution for the issue 105.

https://github.com/eclipse-cyclonedds/cyclonedds-python/issues/105

With this change, now, the IDL file can contain reserved Python keywords and when this IDL file is translated into Python the IDLC Python plugin has been modified to add a prefix "_" to the found reserved keywords.

We have had into account all the posible declaration using IDL: structs, modules, enums, typedefs...

We have tested broadly this change. The developed and executed tests can be review in detail in this git repository:

https://github.com/javiersorianoruiz/cyclonedds-python-checkReservedKeyword

These are not the formal tests that maybe are required by cyclonedds-python project, but they have allowed us to verify that the implementation is right and have no colateral issues.

Maybe, It would be needed to develop another test batery based on pytest and integrated into cyclonedds-python project, following your testing architecteture, What do you think?, Is it needed?