### PR TITLE
Fix for IDL bitmask type in cli tool

### DIFF
--- a/cyclonedds/tools/cli/idl.py
+++ b/cyclonedds/tools/cli/idl.py
@@ -210,7 +210,7 @@ class IdlType:
 
             scope, enname = cls._scoped_name(_type.__idl_typename__)
             out += f"bitmask {enname} {{"
-            for name, _type in get_extended_type_hints(_type).items():
+            for name, __type in get_extended_type_hints(_type).items():
                 out += f"\n    @position({_type.__idl_positions__[name]}) {name},"
             out = out[:-1]
             out += f"\n}};\n"


### PR DESCRIPTION
A fix for printing bitmask types in the cli tool, in case any of the bitfields have the `@position` set. 