### PR TITLE
Minor fix to Working with IDL docs

### DIFF
--- a/docs/manual/idl.rst
+++ b/docs/manual/idl.rst
@@ -281,7 +281,7 @@ In IDL you can annotate structs and members with several different annotations, 
    @dataclass
    class Type1(IdlStruct):
       id: int
-      key(id)
+      key("id")
       value: str
 
    @dataclass


### PR DESCRIPTION
This pull request fixes an issue with the sample code in the Idl Annotations section. Specifically key(id) should be key("id"). As currently defined the sample code raises a TypeError.