### PR TITLE
#187 Modified implementation to construct domain participants on the default domain

### DIFF
--- a/clayer/pysertype.c
+++ b/clayer/pysertype.c
@@ -2383,6 +2383,7 @@ PyMODINIT_FUNC PyInit__clayer(void) {
 
     PyModule_AddObject(module, "DDS_INFINITY", PyLong_FromLongLong(DDS_INFINITY));
     PyModule_AddObject(module, "UINT32_MAX", PyLong_FromUnsignedLong(UINT32_MAX));
+    PyModule_AddObject(module, "DDS_DOMAIN_DEFAULT", PyLong_FromUnsignedLong(DDS_DOMAIN_DEFAULT));
 #ifdef DDS_HAS_TYPE_DISCOVERY
     Py_INCREF(Py_True);
     PyModule_AddObject(module, "HAS_TYPE_DISCOVERY", Py_True);

--- a/cyclonedds/domain.py
+++ b/cyclonedds/domain.py
@@ -71,8 +71,7 @@ class DomainParticipant(Entity):
     It serves as root entity for all other entities.
     """
 
-    def __init__(self, domain_id: Optional[int] = dds_domain_default,
-                 qos: Optional[Qos] = None,
+    def __init__(self, domain_id: int = dds_domain_default, qos: Optional[Qos] = None,
                  listener: Optional[Listener] = None):
         """Initialize a DomainParticipant.
 

--- a/cyclonedds/domain.py
+++ b/cyclonedds/domain.py
@@ -13,7 +13,7 @@
 import ctypes as ct
 from typing import List, Optional
 
-from .internal import c_call, dds_c_t
+from .internal import c_call, dds_c_t, dds_domain_default
 from .core import Entity, DDSException, Listener
 from .topic import Topic
 from .qos import _CQos, LimitedScopeQos, DomainParticipantQos, Qos
@@ -71,13 +71,14 @@ class DomainParticipant(Entity):
     It serves as root entity for all other entities.
     """
 
-    def __init__(self, domain_id: int = 0, qos: Optional[Qos] = None,
+    def __init__(self, domain_id: Optional[int] = dds_domain_default,
+                 qos: Optional[Qos] = None,
                  listener: Optional[Listener] = None):
         """Initialize a DomainParticipant.
 
         Parameters
         ----------
-        domain_id: int, optional, default 0
+        domain_id: int, optional, default as per Cyclone DDS configuration
             The DDS Domain to use
         qos: cyclonedds.qos.Qos, optional, default None
             Apply DomainParticipant Qos.

--- a/cyclonedds/internal.py
+++ b/cyclonedds/internal.py
@@ -397,3 +397,4 @@ dds_infinity: int = _clayer.DDS_INFINITY
 uint32_max: int = _clayer.UINT32_MAX
 feature_type_discovery = _clayer.HAS_TYPE_DISCOVERY
 feature_topic_discovery = _clayer.HAS_TOPIC_DISCOVERY
+dds_domain_default: int = _clayer.DDS_DOMAIN_DEFAULT

--- a/cyclonedds/tools/cli/data/__init__.py
+++ b/cyclonedds/tools/cli/data/__init__.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any
+from typing import Any, Optional
 from cyclonedds import qos, domain, sub, topic
 
 from ..utils import LiveData
@@ -7,13 +7,16 @@ from ..utils import LiveData
 
 def subscribe(
     live: LiveData,
-    domain_id: int,
+    domain_id: Optional[int],
     topic_name: str,
     datatype: Any,
     topicqos: qos.Qos,
     readerqos: qos.Qos,
 ):
-    dp = domain.DomainParticipant(domain_id)
+    if domain_id is None:
+        dp = domain.DomainParticipant()
+    else:
+        dp = domain.DomainParticipant(domain_id)
     tp = topic.Topic(dp, topic_name, datatype, qos=topicqos)
     rd = sub.DataReader(dp, tp, qos=readerqos)
 

--- a/cyclonedds/tools/cli/ddsperf.py
+++ b/cyclonedds/tools/cli/ddsperf.py
@@ -89,7 +89,9 @@ anything""",
 @click.option(
     "-i",
     "--domain-id",
+    "--id",
     metavar="<ID>",
+    type=int,
     help="Use domain ID instead of the default domain",
 )
 @click.option(

--- a/cyclonedds/tools/cli/discovery/main.py
+++ b/cyclonedds/tools/cli/discovery/main.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import time
 import re
-from typing import List
+from typing import List, Optional
 from cyclonedds import core, domain, builtin, dynamic, util, internal
 from datetime import datetime, timedelta
 from collections import defaultdict
@@ -14,14 +14,17 @@ from .type_discoverables import DiscoveredType, TypeDiscoveryData
 
 
 def ls_discovery(
-    live: LiveData, domain_id: int, runtime: timedelta, topic: str, show_qos: bool
+    live: LiveData, domain_id: Optional[int], runtime: timedelta, topic: str, show_qos: bool
 ) -> List[DParticipant]:
     try:
         topic_re = re.compile(f"^{topic}$")
     except re.error:
         topic_re = re.compile(f"^{re.escape(topic)}$")
 
-    dp = domain.DomainParticipant(domain_id)
+    if domain_id is None:
+        dp = domain.DomainParticipant()
+    else:
+        dp = domain.DomainParticipant(domain_id)
 
     rdp = builtin.BuiltinDataReader(dp, builtin.BuiltinTopicDcpsParticipant)
     rcp = core.ReadCondition(
@@ -153,14 +156,17 @@ def ls_discovery(
 
 
 def ps_discovery(
-    live: LiveData, domain_id: int, runtime: timedelta, show_self: bool, topic: str
+    live: LiveData, domain_id: Optional[int], runtime: timedelta, show_self: bool, topic: str
 ) -> List[PApplication]:
     try:
         topic_re = re.compile(f"^{topic}$")
     except re.error:
         topic_re = re.compile(f"^{re.escape(topic)}$")
 
-    dp = domain.DomainParticipant(domain_id)
+    if domain_id is None:
+        dp = domain.DomainParticipant()
+    else:
+        dp = domain.DomainParticipant(domain_id)
 
     rdp = builtin.BuiltinDataReader(dp, builtin.BuiltinTopicDcpsParticipant)
     rcp = core.ReadCondition(
@@ -274,9 +280,12 @@ def ps_discovery(
 
 
 def type_discovery(
-    live: LiveData, domain_id: int, runtime: timedelta, topic: str
+    live: LiveData, domain_id: Optional[int], runtime: timedelta, topic: str
 ) -> List[PApplication]:
-    dp = domain.DomainParticipant(domain_id)
+    if domain_id is None:
+        dp = domain.DomainParticipant()
+    else:
+        dp = domain.DomainParticipant(domain_id)
 
     rdw = builtin.BuiltinDataReader(dp, builtin.BuiltinTopicDcpsPublication)
     rcw = core.ReadCondition(

--- a/cyclonedds/tools/cli/ls.py
+++ b/cyclonedds/tools/cli/ls.py
@@ -8,7 +8,7 @@ from .discovery.main import ls_discovery
 
 @click.command(short_help="Scan and display DDS entities in your network")
 @click.option(
-    "-i", "--id", "--domain-id", type=int, default=0, help="DDS Domain to inspect."
+    "-i", "--id", "--domain-id", type=int, help="DDS Domain to inspect."
 )
 @click.option(
     "-r",

--- a/cyclonedds/tools/cli/ps.py
+++ b/cyclonedds/tools/cli/ps.py
@@ -8,7 +8,7 @@ from .discovery.main import ps_discovery
 
 @click.command(short_help="Scan and display DDS applications in your network")
 @click.option(
-    "-i", "--id", "--domain-id", type=int, default=0, help="DDS Domain to inspect."
+    "-i", "--id", "--domain-id", type=int, help="DDS Domain to inspect."
 )
 @click.option(
     "-r",

--- a/cyclonedds/tools/cli/pub.py
+++ b/cyclonedds/tools/cli/pub.py
@@ -28,7 +28,7 @@ from .common import select_type, select_qos
 @click.command(short_help="Publish to an arbitrary topic")
 @click.argument("topic")
 @click.option(
-    "-i", "--id", "--domain-id", type=int, default=0, help="DDS Domain to inspect."
+    "-i", "--id", "--domain-id", type=int, help="DDS Domain to inspect."
 )
 @click.option(
     "-r",
@@ -107,7 +107,10 @@ def publish(topic, id, runtime, suppress_progress_bar, color, qos, type):
     )
     console.print("[bold green] Publishing, run exit() to quit")
 
-    dp = domain.DomainParticipant(id)
+    if id is None:
+        dp = domain.DomainParticipant()
+    else:
+        dp = domain.DomainParticipant(id)
     tp = cyclone_topic.Topic(dp, topic, discovered_type.dtype, qos=qos_topic)
     dw = pub.DataWriter(dp, tp, qos=qos_endpoint)
 

--- a/cyclonedds/tools/cli/sub.py
+++ b/cyclonedds/tools/cli/sub.py
@@ -22,7 +22,7 @@ from .common import select_type, select_qos
 @click.command(short_help="Subscribe to an arbitrary topic")
 @click.argument("topic")
 @click.option(
-    "-i", "--id", "--domain-id", type=int, default=0, help="DDS Domain to inspect."
+    "-i", "--id", "--domain-id", type=int, help="DDS Domain to inspect."
 )
 @click.option(
     "-r",

--- a/cyclonedds/tools/cli/typeof.py
+++ b/cyclonedds/tools/cli/typeof.py
@@ -10,7 +10,7 @@ from .discovery.main import type_discovery
 @click.command(short_help="Fetch and display reconstructed IDL of a type over XTypes")
 @click.argument("topic")
 @click.option(
-    "-i", "--id", "--domain-id", type=int, default=0, help="DDS Domain to inspect."
+    "-i", "--id", "--domain-id", type=int, help="DDS Domain to inspect."
 )
 @click.option(
     "-r",

--- a/cyclonedds/tools/ddsls/__init__.py
+++ b/cyclonedds/tools/ddsls/__init__.py
@@ -171,7 +171,7 @@ def parse_args(args):
 
 def create_parser(args):
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--id", type=int, help="Define the domain participant id", default=0)
+    parser.add_argument("-i", "--id", type=int, help="Define the domain participant id")
     parser.add_argument("-f", "--filename", type=str, help="Write results to file in JSON format")
     parser.add_argument("-j", "--json", action="store_true", help="Print output in JSON format")
     parser.add_argument("-w", "--watch", action="store_true", help="Watch for data reader & writer & qoses changes")
@@ -207,7 +207,10 @@ def main(sys_args):
     JsonWriter.reset()
     managers = []
     args = create_parser(sys_args)
-    dp = DomainParticipant(args.id)
+    if args.id is None:
+        dp = DomainParticipant()
+    else:
+        dp = DomainParticipant(args.id)
     topics = parse_args(args)
     waitset = WaitSet(dp)
 

--- a/cyclonedds/tools/pubsub/__init__.py
+++ b/cyclonedds/tools/pubsub/__init__.py
@@ -34,6 +34,7 @@ def create_parser(args):
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("-T", "--topic", type=str, help="The name of the topic to publish/subscribe to")
     group.add_argument("-D", "--dynamic", type=str, help="Dynamically publish/subscribe to a topic")
+    parser.add_argument("-i", "--id", type=int, help="Define the domain participant id")
     parser.add_argument("-f", "--filename", type=str, help="Write results to file in JSON format")
     parser.add_argument("-eqos", "--entityqos", choices=["all", "topic", "publisher", "subscriber",
                         "datawriter", "datareader"], default=None, help="""Select the entites to set the qos.
@@ -167,7 +168,11 @@ def main(sys_args):
         qos = QosParser.parse(args.qos)
         eqos.entity_qos(qos, args.entityqos)
 
-    dp = DomainParticipant(0)
+    if args.id is None:
+        dp = DomainParticipant()
+    else:
+        dp = DomainParticipant(args.id)
+
     waitset = WaitSet(dp)
     manager = TopicManager(args, dp, eqos, waitset)
     if args.topic or args.dynamic:

--- a/docs/manual/tools.ddsls.rst
+++ b/docs/manual/tools.ddsls.rst
@@ -121,7 +121,7 @@ Comprehend output
 Domain participant id
 ^^^^^^^^^^^^^^^^^^^^^
 
-By default, the **ddsls** subscribes to the default domain (domain 0) and displays information of entities in that domain. However, if you want to view the entity information in another domain, you can use the option ``-- id`` to change the domain to which the **ddsls** subscribes.
+By default, the **ddsls** subscribes to the default domain (domain 0 unless otherwise configured) and displays information of entities in that domain. However, if you want to view the entity information in another domain, you can use the option ``-- id`` to change the domain to which the **ddsls** subscribes.
 
 The ``--id`` option will set the id of the **ddsls** domain participant, allowing the **ddsls** to view entities in the domain you chooses.
 

--- a/examples/async/async_subscriber.py
+++ b/examples/async/async_subscriber.py
@@ -29,18 +29,18 @@ listener = MyListener()
 qos = Qos(
     Policy.Reliability.BestEffort,
     Policy.Deadline(duration(microseconds=10)),
-    Policy.Durability.Transient,
+    Policy.Durability.TransientLocal,
     Policy.History.KeepLast(10)
 )
 
-domain_participant = DomainParticipant(0)
+domain_participant = DomainParticipant()
 topic = Topic(domain_participant, 'Vehicle', Vehicle, qos=qos)
 subscriber = Subscriber(domain_participant)
 reader = DataReader(domain_participant, topic, listener=listener)
 
 
 async def task1(reader):
-    async for sample in reader.take_aiter(timeout=duration(seconds=2)):
+    async for sample in reader.take_aiter(timeout=duration(seconds=10)):
         print(sample)
 
 

--- a/examples/async/async_subscriber.py
+++ b/examples/async/async_subscriber.py
@@ -40,7 +40,7 @@ reader = DataReader(domain_participant, topic, listener=listener)
 
 
 async def task1(reader):
-    async for sample in reader.take_aiter(timeout=duration(seconds=10)):
+    async for sample in reader.take_aiter(timeout=duration(seconds=2)):
         print(sample)
 
 

--- a/examples/async/vehicles.py
+++ b/examples/async/vehicles.py
@@ -10,10 +10,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 """
 
+from dataclasses import dataclass
+
 from cyclonedds.idl import IdlStruct
 from cyclonedds.idl.types import int64
 
-
+@dataclass
 class Vehicle(IdlStruct):
     name: str
     x: int64

--- a/examples/builtin_topics/participants.py
+++ b/examples/builtin_topics/participants.py
@@ -15,7 +15,7 @@ from cyclonedds.builtin import BuiltinDataReader, BuiltinTopicDcpsParticipant
 from cyclonedds.util import duration
 
 
-# Create a DomainParticipant in domain 0
+# Create a DomainParticipant in the default domain
 dp = DomainParticipant()
 
 # Create a datareader that can read from the builtin participant topic

--- a/examples/helloworld/helloworld.py
+++ b/examples/helloworld/helloworld.py
@@ -28,7 +28,7 @@ class HelloWorld(IdlStruct, typename="HelloWorld.Msg"):
 
 
 # Create a DomainParticipant, your entrypoint to DDS
-# The default domain id is 0.
+# Created in the default domain
 dp = DomainParticipant()
 
 # Create a Topic with topic name "Hello" and as datatype "HelloWorld" structs.

--- a/examples/vehicle/publisher.py
+++ b/examples/vehicle/publisher.py
@@ -34,7 +34,7 @@ qos = Qos(
     Policy.History.KeepLast(10)
 )
 
-domain_participant = DomainParticipant(0)
+domain_participant = DomainParticipant()
 topic = Topic(domain_participant, 'Vehicle', Vehicle, qos=qos)
 publisher = Publisher(domain_participant)
 writer = DataWriter(publisher, topic)

--- a/examples/vehicle/subscriber.py
+++ b/examples/vehicle/subscriber.py
@@ -36,7 +36,7 @@ qos = Qos(
     Policy.History.KeepLast(10)
 )
 
-domain_participant = DomainParticipant(0)
+domain_participant = DomainParticipant()
 topic = Topic(domain_participant, 'Vehicle', Vehicle, qos=qos)
 subscriber = Subscriber(domain_participant)
 reader = DataReader(domain_participant, topic, listener=listener)


### PR DESCRIPTION
Modified the implementation to construct domain participants on the default domain (as determined by the Cyclone DDS configuration) by default unless users provide a domain Id when constructing a domain participant.

The proposed solution could potentially affect existing applications as, depending on configuration, user applications may run by default on a domain other than 0 as they would have previously. However, this may actually be desirable. An alternative if this is problematic would be to add a classmethod to Domain to return the default domain Id constant in a similar way to the C++ binding.

I've also updated the examples and tooling to use the default domain by default.

I also found the async example wasn't working with the regular vehicle publisher. I've modified the implementation to ensure the examples are able to communicate as part of the testing.