### PR TITLE
Fix key serialization for mutable structs with struct-type member

### DIFF
--- a/cyclonedds/idl/_machinery.py
+++ b/cyclonedds/idl/_machinery.py
@@ -1038,7 +1038,7 @@ class PLCdrMutableStructMachine(Machine):
             if mutablemember.lentype == LenType.NextIntLen:
                 buffer.write('I', 4, 0)
 
-            mutablemember.machine.serialize(buffer, member_value)
+            mutablemember.machine.serialize(buffer, member_value, serialize_kind)
 
             if mutablemember.lentype == LenType.NextIntLen:
                 ampos = buffer.tell()

--- a/tests/support_modules/fuzz_tools/rand_idl/naming.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/naming.py
@@ -18,7 +18,7 @@ class Namer:
         "annotation", "const", "native", "typedef", "union", "switch", "case", "default",
         "enum", "fixed", "string", "sequence", "wstring", "float", "double", "char", "wchar",
         "boolean", "bool", "octet", "any", "bitset", "bitmap", "int", "uint", "true", "false",
-        "del", "class", "not", "def"
+        "del", "class", "not", "def", "get", "set", "static"
     ]
 
     def __init__(self, seed, prefix, parent=None) -> None:


### PR DESCRIPTION
This fixes the key serialization for a mutable struct that has a key member with a struct type that contains 1+ non-key members. The `serialize_kind` was not passed to the nested serialize call, which resulted in non-key members of the nested type being added to the key.

Additionally a few entries are added to the reserved name list in the random IDL generator. This solves some runtime errors in fuzzer runs (`TypeError: 'list' object is not callable` and `expected identifier or '(' before 'static'`)