### PR TITLE
Make `cyclonedds typeof` work on derived types

### DIFF
--- a/cyclonedds/idl/__init__.py
+++ b/cyclonedds/idl/__init__.py
@@ -39,7 +39,7 @@ class IdlStruct(metaclass=IdlMeta):
 def make_idl_struct(class_name: str, typename: str, fields: Dict[str, Any], *, dataclassify=True,
                     field_annotations: Optional[Dict[str, Dict[str, Any]]] = None,
                     bases: Tuple[Type[IdlStruct], ...] = ()) -> Type[IdlStruct]:
-    bases = tuple(list(*bases) + [IdlStruct])
+    bases = tuple(list(bases) + [IdlStruct])
     namespace = IdlMeta.__prepare__(class_name, bases, typename=typename)
 
     for fieldname, _type in fields.items():

--- a/cyclonedds/tools/cli/idl.py
+++ b/cyclonedds/tools/cli/idl.py
@@ -161,9 +161,19 @@ class IdlType:
             out = cls._annot(_type)
 
             scope, enname = cls._scoped_name(_type.__idl__.idl_transformed_typename)
-            out += f"struct {enname} {{"
+            out += f"struct {enname} "
+            basefields = []
+            if issubclass(_type.__base__, IdlStruct) and _type.__base__ != IdlStruct:
+                base = _type.__base__
+                cls._proc_type(state, base)
+                basefields = [n for n, t in get_extended_type_hints(base).items()]
+                _, basename = cls._scoped_name(base.__idl__.idl_transformed_typename)
+                out += f": {basename} "
+            out += "{"
             field_annot = get_idl_field_annotations(_type)
             for name, _type in get_extended_type_hints(_type).items():
+                if name in basefields:
+                    continue
                 out += "\n    "
                 if "key" in field_annot.get(name, {}):
                     out += "@key "


### PR DESCRIPTION
This solves
```
  File "/usr/lib64/python3.11/site-packages/cyclonedds/idl/__init__.py", line 39, in make_idl_struct
    bases = tuple(list(*bases) + [IdlStruct])
                  ^^^^^^^^^^^^
TypeError: 'IdlMeta' object is not iterable
```
when `cyclonedds typeof` is used to print a derived type.

With this change it prints the fields including those of the base type, but not the fact that is actually a derived type:
```
As defined in participant(s) 011015d7-62dd-3bff-a9fa-efb3000001c1
module Hierarchy {                                                                     
    @mutable                                                                           
    struct Base {                                                                      
        string fieldA;                                                                 
    };                                                                                 
};                                                                                     

As defined in participant(s) 011015d7-62dd-3bff-a9fa-efb3000001c1
module Hierarchy {                                                                     
    @mutable                                                                           
    struct Derived {                                                                   
        string fieldA;                                                                 
        string fieldB;                                                                 
    };                                                                                 
};                                                                                     
```
What I would like to see is of course:
```
module Hierarchy {                                                                     
    @mutable                                                                           
    struct Base {                                                                      
        string fieldA;                                                                 
    };                                                                                 
    @mutable                                                                           
    struct Derived : Base {                                                                   
        string fieldB;                                                                 
    };                                                                                 
};                                                                                     
```

Fixes #241 in the narrow sense that the error goes away and it does something at least somewhat useful.