### PR TITLE
Prepend _ to value, discriminator in union

### DIFF
--- a/cyclonedds/idl/_main.py
+++ b/cyclonedds/idl/_main.py
@@ -472,6 +472,8 @@ class IdlUnionMeta(IdlMeta):
         for name, _type in new_cls.__annotations__.items():
             if get_origin(_type) != Annotated and len(get_args(_type)) != 2:
                 raise TypeError(f"Fields of a union need to be case or default, '{name}: {_type}' is not.")
+            if name in ['value', 'discriminator']:
+                raise TypeError(f"Field name '{name}' is disallowed in a union, perhaps '_{name}' was meant?")
 
             _type = get_args(_type)[1]
             if isinstance(_type, types.case):

--- a/cyclonedds/tools/cli/idl.py
+++ b/cyclonedds/tools/cli/idl.py
@@ -180,7 +180,10 @@ class IdlType:
                 out += "\n    "
                 if "key" in field_annot.get(name, {}):
                     out += "@key "
-                out += cls._kind_type(state, _type) + f" {name}"
+                realName = name
+                if name in field_annot and "name" in field_annot[name]:
+                    realName = field_annot[name]["name"]
+                out += cls._kind_type(state, _type) + f" {realName}"
                 for arr in cls._array_size(_type):
                     out += f"[{arr}]"
                 out += ";"
@@ -195,6 +198,7 @@ class IdlType:
             out += (
                 " switch (" + cls._kind_type(state, _type.__idl_discriminator__) + ") {"
             )
+            field_annot = get_idl_field_annotations(_type)
             for name, __type in get_extended_type_hints(_type).items():
                 if isinstance(__type, pt.case):
                     for l in __type.labels:
@@ -211,7 +215,10 @@ class IdlType:
                 else:
                     out += "\n    default:"
 
-                out += "\n        " + cls._kind_type(state, __type.subtype) + f" {name}"
+                realName = name
+                if name in field_annot and "name" in field_annot[name]:
+                    realName = field_annot[name]["name"]
+                out += "\n        " + cls._kind_type(state, __type.subtype) + f" {realName}"
                 for arr in cls._array_size(__type.subtype):
                     out += f"[{arr}]"
                 out += ";"

--- a/idlpy/src/types.c
+++ b/idlpy/src/types.c
@@ -142,6 +142,7 @@ emit_field(
 
     //Reserved Python keywords support (Issue 105)
     const char *name = idlpy_identifier(node);
+    const char *name_prefix = "";
     ////////////////////////////
     const void* type_spec;
 
@@ -193,12 +194,14 @@ emit_field(
         }
     }
 
-
-    idlpy_ctx_printf(ctx, "\n    %s: %s", name, type);
+    if ((idl_is_default_case(parent) || idl_is_case(parent)) &&
+        (strcmp (name, "value") == 0 || strcmp (name, "discriminator") == 0))
+      name_prefix = "_";
+    idlpy_ctx_printf(ctx, "\n    %s%s: %s", name_prefix, name, type);
 
     //Reserved Python keywords support (Issue 105)
-    if (name != idlpy_identifier(node)) {
-        idlpy_ctx_printf(ctx, "\n    annotate.member_name(\"%s\",\"%s\")", name, idlpy_identifier(node));
+    if (name != idlpy_identifier(node) || name_prefix[0] != 0) {
+      idlpy_ctx_printf(ctx, "\n    annotate.member_name(\"%s%s\",\"%s\")", name_prefix, name, idlpy_identifier(node));
     }
     /////////////////////
 


### PR DESCRIPTION
The use of members named "value" and "discriminator" in a union are problematic because of the existence of properties on the IdlUnion class with these names.  (The error message are quite confusing.)  For example, this:

    union U switch (boolean) {
        case TRUE: string value;
    };

would result in a union where you could not set the value.  You might be able to get it, more or less by accident.  If instead of "value" the member would be named "discriminator", it'd be even worse.

The IDL spec has a mechanism for dealing with these problems: the use of a leading underscore as an keyword escape mechanism, both on the IDL and the language binding.  The Python already used this for keywords, now it also uses it for these two identifiers in unions.  Thus, the above now maps to:

    class U(idl.IdlUnion, discriminator=bool, discriminator_is_key=False, typename="U"):
        _value: types.case[[True], str]
        annotate.member_name("_value","value")

Trying to define a union with these members (without the leading underscore) now raises an exception.  The underscore is not in the TypeObjects and also stripped in the IDL output by `cyclonedds typeof`.

Fixes #245 (@FirebarSim, perhaps you can verify this claim?)