### PR TITLE
update version to 0.10.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from build_ext import build_ext, Library
 from bdist_wheel import bdist_wheel
 
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 package = "cyclonedds"
 
 


### PR DESCRIPTION
This PR bumps the version to 0.10.3 which then can be released. After that i am willing to provide PRs for 0.10.4 and 0.10.5.

I think it would be cool to do all versions 0.10.x versions so thats complete and no release missing.