### PR TITLE
feature/fix-nightly-and-release-mac-os

### DIFF
--- a/.azure/publish-release-nightly.yml
+++ b/.azure/publish-release-nightly.yml
@@ -38,8 +38,8 @@ jobs:
     matrix:
       'Ubuntu_20.04_LTS':
         image: ubuntu-20.04
-      'macOS_11':
-        image: macOS-11
+      'macOS_12':
+        image: macOS-12
       'Windows_Server_2019_64_bit':
         image: windows-2019
   steps:

--- a/.azure/publish-release.yml
+++ b/.azure/publish-release.yml
@@ -38,8 +38,8 @@ jobs:
     matrix:
       'Ubuntu_20.04_LTS':
         image: ubuntu-20.04
-      'macOS_11':
-        image: macOS-11
+      'macOS_12':
+        image: macOS-12
       'Windows_Server_2019_64_bit':
         image: windows-2019
   steps:


### PR DESCRIPTION
This PR bumps the mac-os version of the release and the nightly build jobs because mac-os-11 was removed.