### PR TITLE
Fuzzer: re-serialize in C, check size

### DIFF
--- a/tests/support_modules/fuzz_tools/checks/keys.py
+++ b/tests/support_modules/fuzz_tools/checks/keys.py
@@ -39,7 +39,7 @@ def check_py_c_key_equivalence(log: Stream, ctx: FullContext, typename: str, num
     dw.set_status_mask(DDSStatus.PublicationMatched)
     dw.take_status()
 
-    ctx.c_app.run(typename, len(samples))
+    ctx.c_app.run(typename, len(samples), False)
 
     now = time.time()
     while (dw.take_status() & DDSStatus.PublicationMatched) == 0:

--- a/tests/support_modules/fuzz_tools/checks/mutated.py
+++ b/tests/support_modules/fuzz_tools/checks/mutated.py
@@ -119,7 +119,7 @@ def check_mutation_key(log: Stream, ctx: FullContext, typename: str, num_samples
     dw.set_status_mask(DDSStatus.PublicationMatched)
     dw.take_status()
 
-    ctx.c_app.run(typename, len(samples))
+    ctx.c_app.run(typename, len(samples), True)
 
     now = time.time()
     while (dw.take_status() & DDSStatus.PublicationMatched) == 0:
@@ -237,7 +237,7 @@ def check_enforced_non_communication(log: Stream, ctx: FullContext, typename: st
     dw.set_status_mask(DDSStatus.PublicationMatched)
     dw.take_status()
 
-    ctx.c_app.run(typename, 1)
+    ctx.c_app.run(typename, 1, True)
 
     now = time.time()
     while (dw.take_status() & DDSStatus.PublicationMatched) == 0:

--- a/tests/support_modules/fuzz_tools/rand_idl/c_app.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/c_app.py
@@ -76,5 +76,5 @@ const unsigned long long topic_descriptors_size = {len(types)};
         return executable, dynamic_index_c
 
 
-def run_c_app(executable, type, num_samples):
-    return Popen([executable.name, type, str(num_samples)], stderr=PIPE, stdout=PIPE)
+def run_c_app(executable, type, num_samples, mutated):
+    return Popen([executable.name, type, str(num_samples), "mutated" if mutated else "original"], stderr=PIPE, stdout=PIPE)

--- a/tests/support_modules/fuzz_tools/rand_idl/context_containers.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/context_containers.py
@@ -25,8 +25,8 @@ class CAppContext:
     last_out: str = ""
     process: Optional[Popen] = None
 
-    def run(self, typename: str, num_samples: int) -> None:
-        self.process = Popen([self.executable.name, typename, str(num_samples)], stderr=PIPE, stdout=PIPE)
+    def run(self, typename: str, num_samples: int, mutated: bool) -> None:
+        self.process = Popen([self.executable.name, typename, str(num_samples), "mutated" if mutated else "original"], stderr=PIPE, stdout=PIPE)
 
     def description(self, typename: str) -> Optional[Tuple[bytes, bytes]]:
         self.process = Popen([self.executable.name, typename, "desc"], stderr=PIPE, stdout=PIPE)


### PR DESCRIPTION
Always check that re-serializing for the sample matches the expected length of the serializer output and that the extracted key matches the re-serialized key and its expected serialized size.

It also includes code to check that round-tripping through the C serializer results in the same CDR as Python, but there are is some room for variation in the encoding of mutable types and the two do not always make the same choice. So that needs to be disabled until they always choose the same encoding.

Companion to https://github.com/eclipse-cyclonedds/cyclonedds/pull/2085