### PR TITLE
Enable finding system cyclonedds on debian

### DIFF
--- a/buildhelp/cyclone_search.py
+++ b/buildhelp/cyclone_search.py
@@ -51,6 +51,10 @@ def good_directory(directory: Path):
         if not libdir.exists():
             return None
 
+    multiarch_libdir = libdir / "x86_64-linux-gnu"
+    if multiarch_libdir.exists():
+        libdir = multiarch_libdir
+
     if platform.system() == 'Windows':
         ddsc_library = bindir / "ddsc.dll"
     elif platform.system() == 'Darwin':


### PR DESCRIPTION
On debian and ubuntu the cyclonedds libraries are placed under

/usr/lib/x86_64-linux-gnu

So if x86_64-linux-gnu exists in the lib directory add it to the path