### PR TITLE
Only serialize key when C function asks for a key

### DIFF
--- a/cyclonedds/idl/__init__.py
+++ b/cyclonedds/idl/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 
 from .types import ValidUnionHolder
 from ._main import IdlMeta, IdlUnionMeta, IdlBitmaskMeta, IdlEnumMeta
-from ._support import Buffer, Endianness
+from ._support import Buffer, Endianness, SerializeKind
 
 
 _TIS = TypeVar('_TIS', bound='IdlStruct')
@@ -27,6 +27,9 @@ _TIE = TypeVar('_TIE', bound='IdlEnum')
 class IdlStruct(metaclass=IdlMeta):
     def serialize(self, buffer: Optional[Buffer] = None, endianness: Optional[Endianness] = None, use_version_2: Optional[bool] = None) -> bytes:
         return self.__idl__.serialize(self, buffer=buffer, endianness=endianness, use_version_2=use_version_2)
+
+    def serialize_key(self, endianness: Optional[Endianness] = None, use_version_2: Optional[bool] = None) -> bytes:
+        return self.__idl__.serialize(self, endianness=endianness, use_version_2=use_version_2, serialize_kind=SerializeKind.KeyDefinitionOrder)
 
     @classmethod
     def deserialize(cls: Type[_TIS], data: bytes, has_header: bool = True, use_version_2: Optional[bool] = None) -> _TIS:

--- a/cyclonedds/pub.py
+++ b/cyclonedds/pub.py
@@ -226,7 +226,7 @@ class DataWriter(Entity, Generic[_T]):
         timestamp
             The sample's source_timestamp (in nanoseconds since the UNIX Epoch)
         """
-        ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = sample.serialize_key(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
@@ -258,8 +258,9 @@ class DataWriter(Entity, Generic[_T]):
             raise DDSException(ret, f"Occurred while disposing in {repr(self)}")
 
     def register_instance(self, sample: _T) -> int:
-        ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = sample.serialize_key(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
+        print(f"ser={ser}")
 
         ret = ddspy_register_instance(self._ref, ser)
         if ret < 0:
@@ -275,7 +276,7 @@ class DataWriter(Entity, Generic[_T]):
         timestamp
             The timestamp used at registration (in nanoseconds since the UNIX Epoch)
         """
-        ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = sample.serialize_key(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         if timestamp is not None:
@@ -326,7 +327,7 @@ class DataWriter(Entity, Generic[_T]):
         """
         This operation takes a sample and returns an instance handle to be used for subsequent operations.
         """
-        ser = sample.serialize(use_version_2=self._use_version_2)
+        ser = sample.serialize_key(use_version_2=self._use_version_2)
         ser = ser.ljust((len(ser) + 4 - 1) & ~(4 - 1), b'\0')
 
         ret = ddspy_lookup_instance(self._ref, ser)

--- a/cyclonedds/sub.py
+++ b/cyclonedds/sub.py
@@ -371,7 +371,7 @@ class DataReader(Entity, Generic[_T]):
         raise DDSException(ret, f"Occured while waiting for historical data in {repr(self)}")
 
     def lookup_instance(self, sample: _T) -> Optional[int]:
-        ret = ddspy_lookup_instance(self._ref, sample.serialize())
+        ret = ddspy_lookup_instance(self._ref, sample.serialize_key())
         if ret < 0:
             raise DDSException(ret, f"Occurred while lookup up instance from {repr(self)}")
         if ret == 0:


### PR DESCRIPTION
For some operations, the DDS API requires a key instead of a sample ("dispose" is one of those), and does this by invoking the "ddsi_serdata_from_sample" operation with kind set to "SDK_KEY".

The Python binding is a bit unusual in that it serializes the data before calling into C because that allows using Python code to serialize the data without having to call back into Python code from C or being forced to interpret Python objects from C.  A mismatch is possible, and this causes failures if the serialized form of the key is not a prefix of the serialized form of the full sample.  For example:

    @dataclass
    class S(idl.IdlStruct, typename="S"):
        v: int
        k: int
        key("k")

    ih0 = dw.register_instance(S(0, 1))

Will misinterpret the bytes and treat the key value as 0 instead of as 1.

It can be dealt with in two ways:

* One is to continue always serializing a full sample in Python, fixing it up in the serdata implementation if a serialized key is requested.  This is small change in the Python "clayer";
* The other is to serialize a key when a key is expected. This is somewhat fragile, but the list of operations is small and the API rather stable.

This commit implements the second option, and mostly because it means the serializer will not touch the non-key fields.

Intended to fix #269