### PR TITLE
Fix invalid syntax in cli for python3.7

### DIFF
--- a/cyclonedds/tools/cli/idl.py
+++ b/cyclonedds/tools/cli/idl.py
@@ -127,7 +127,7 @@ class IdlType:
         if isinstance(_type, array):
             inner = cls._array_size(_type.subtype)
             if inner is not None:
-                return _type.length, *inner
+                return (_type.length, *inner)
             return (_type.length,)
         return tuple()
 


### PR DESCRIPTION
Python 3.7 does not support unpacking without parentheses in return statements