### PR TITLE
Inherit member ids from base for dyn disc type

### DIFF
--- a/cyclonedds/idl/_builder.py
+++ b/cyclonedds/idl/_builder.py
@@ -261,6 +261,7 @@ class Builder:
                     else:
                         lentype = LenType.NextIntLen
 
+                    assert struct.__idl__.get_member_id(name) >= 0
                     mutablemembers.append(MutableMember(
                         name=name,
                         key=keylist and name in keylist,

--- a/cyclonedds/idl/_xt_builder.py
+++ b/cyclonedds/idl/_xt_builder.py
@@ -1578,9 +1578,13 @@ class XTInterpreter:
 
         types = {}
         annotations = {}
-        member_ids = {}
 
-        bases = (base,) if base is not None else tuple()
+        if base is None:
+            bases = tuple()
+            member_ids = {}
+        else:
+            bases = (base,)
+            member_ids = base.__idl__.member_ids
         defers = []
 
         for m in pre_struct.member_seq:


### PR DESCRIPTION
This adds the the member ids from the base type to the member ids of a struct when dynamically constructing a struct type from a TypeObject.

Without this step, the inherited fields end up getting member id -1 somewhere in the of the deserializer and cause the inherited fields to not be found during deserialization.  Because of this, none of the inherited fields will be deserialized and a must-understand field (which includes key fields) among them causes a deserialization error.