### PR TITLE
Add sequence and array as key in fuzzer

### DIFF
--- a/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
+++ b/tests/support_modules/fuzz_tools/rand_idl/c_app/xtypes_sub.c
@@ -169,7 +169,7 @@ static void check_cdrsize(const unsigned char *buf, uint32_t bufsz, uint16_t enc
 
     const size_t size = dds_stream_getsize_sample (obj, desc, os.m_xcdr_version);
     assert (size == os.m_index);
-    const size_t keysize = dds_stream_getsize_key (DDS_CDR_KEY_SERIALIZATION_SAMPLE, obj, desc, os.m_xcdr_version);
+    const size_t keysize = dds_stream_getsize_key (obj, desc, os.m_xcdr_version);
     assert (keysize == extracted_keysize);
 
     // Small details in (mutable) CDR enconding make this painful.

--- a/tests/support_modules/fuzz_tools/rand_idl/mutator.py
+++ b/tests/support_modules/fuzz_tools/rand_idl/mutator.py
@@ -61,7 +61,7 @@ def mutate(top_scope: cn.RScope, seed):
     avoid_mutating = set()
     def scan_avoid_mutating_field(field: cn.RField):
         nonlocal avoid_mutating
-        if field.array_bound is not None or field.type.discriminator in [cn.RTypeDiscriminator.Sequence, cn.RTypeDiscriminator.BoundedSequence]:
+        if field.array_bound is not None or field.type.discriminator in [cn.RTypeDiscriminator.Sequence, cn.RTypeDiscriminator.BoundedSequence, cn.RTypeDiscriminator.Nested]:
             dependencies = field.depending()
             if dependencies and isinstance(dependencies[0], (cn.RStruct, cn.RUnion)) and \
                     dependencies[0].extensibility in [cn.RExtensibility.NotSpecified, cn.RExtensibility.Final]:
@@ -83,7 +83,7 @@ def mutate(top_scope: cn.RScope, seed):
                 if entity.default:
                     scan_avoid_mutating_field(entity.default)
         if isinstance(entity, cn.RTypedef):
-            if entity.array_bound or entity.rtype.discriminator in [cn.RTypeDiscriminator.Sequence, cn.RTypeDiscriminator.BoundedSequence]:
+            if entity.array_bound or entity.rtype.discriminator in [cn.RTypeDiscriminator.Sequence, cn.RTypeDiscriminator.BoundedSequence, cn.RTypeDiscriminator.Nested]:
                 dependencies = entity.rtype.depending()
                 if dependencies and isinstance(dependencies[0], (cn.RStruct, cn.RUnion)) and \
                         dependencies[0].extensibility in [cn.RExtensibility.NotSpecified, cn.RExtensibility.Final]:


### PR DESCRIPTION
Updates the IDL fuzzer so that sequences and arrays with any supported element type (all types except union) can be included in a data type's key.

Related to https://github.com/eclipse-cyclonedds/cyclonedds/pull/2203