### PR TITLE
Isolate test runs by creating domain with process-specific domain-tag

### DIFF
--- a/tests/support_modules/test_tools/fixtures.py
+++ b/tests/support_modules/test_tools/fixtures.py
@@ -1,9 +1,9 @@
-import threading
+import threading, os
 from datetime import datetime
 from typing import Optional, List
 
 from cyclonedds.core import Qos, Policy
-from cyclonedds.domain import DomainParticipant
+from cyclonedds.domain import Domain, DomainParticipant
 from cyclonedds.topic import Topic
 from cyclonedds.pub import Publisher, DataWriter
 from cyclonedds.sub import Subscriber, DataReader
@@ -12,8 +12,13 @@ from cyclonedds.util import duration
 from ..testtopics import Message
 
 
-class Common:
+class DomainTag:
     def __init__(self, domain_id=0):
+        self.d = Domain(domain_id, f"<Discovery><Tag>pytest_domain_{os.getpid()}</Tag></Discovery>")
+
+class Common(DomainTag):
+    def __init__(self, domain_id=0):
+        super().__init__(domain_id)
         self.qos = Qos(Policy.Reliability.Reliable(duration(seconds=2)), Policy.History.KeepLast(10))
 
         self.dp = DomainParticipant(domain_id)
@@ -26,8 +31,9 @@ class Common:
         self.msg2 = Message(message="hi2")
 
 
-class Manual:
+class Manual(DomainTag):
     def __init__(self, domain_id=0):
+        super().__init__(domain_id)
         self.qos = Qos(Policy.Reliability.Reliable(duration(seconds=2)), Policy.History.KeepLast(10))
 
         self.dp = DomainParticipant(domain_id)

--- a/tests/test_builtin.py
+++ b/tests/test_builtin.py
@@ -13,8 +13,8 @@ requires_dcps_topic = pytest.mark.skipif(
     not cyclonedds.internal.feature_topic_discovery, reason="Cannot use BuiltinTopicDcpsTopic since topic discovery is disabled."
 )
 
-def test_builtin_dcps_participant():
-    dp = DomainParticipant(0)
+def test_builtin_dcps_participant(manual_setup):
+    dp = manual_setup.dp
     sub = Subscriber(dp)
     dr1 = BuiltinDataReader(sub, BuiltinTopicDcpsParticipant)
     dr2 = BuiltinDataReader(sub, BuiltinTopicDcpsSubscription)
@@ -26,8 +26,8 @@ def test_builtin_dcps_participant():
     assert {msg[0].key, msg[1].key} == {dr1.guid, dr2.guid}
 
 
-def test_builtin_dcps_participant_read_next():
-    dp = DomainParticipant(0)
+def test_builtin_dcps_participant_read_next(manual_setup):
+    dp = manual_setup.dp
     sub = Subscriber(dp)
     dr1 = BuiltinDataReader(sub, BuiltinTopicDcpsParticipant)
     dr2 = BuiltinDataReader(sub, BuiltinTopicDcpsSubscription)
@@ -39,8 +39,8 @@ def test_builtin_dcps_participant_read_next():
     assert {msg[0].key, msg[1].key} == {dr1.guid, dr2.guid}
 
 
-def test_builtin_dcps_participant_iter():
-    dp = DomainParticipant(0)
+def test_builtin_dcps_participant_iter(manual_setup):
+    dp = manual_setup.dp
     sub = Subscriber(dp)
     dr1 = BuiltinDataReader(sub, BuiltinTopicDcpsParticipant)
     dr2 = BuiltinDataReader(sub, BuiltinTopicDcpsSubscription)
@@ -52,14 +52,13 @@ def test_builtin_dcps_participant_iter():
         assert msg.key == dp.guid
 
     for msg in dr2.take_iter(timeout=duration(milliseconds=10)):
-        msg.key in [dr1.guid, dr2.guid]
+        assert msg.key in [dr1.guid, dr2.guid]
 
 
 @requires_dcps_topic
-def test_builtin_dcps_topic_read():
-    dp = DomainParticipant(0)
+def test_builtin_dcps_topic_read(manual_setup):
+    dp = manual_setup.dp
     tdr = BuiltinDataReader(dp, BuiltinTopicDcpsTopic)
-
     tp = Topic(dp, 'MessageTopic', Message)
 
     # assert tp.typename == tp.get_type_name() == 'Message'
@@ -74,8 +73,8 @@ def test_builtin_dcps_topic_read():
 
 
 @requires_dcps_topic
-def test_builtin_dcps_topic_take():
-    dp = DomainParticipant(0)
+def test_builtin_dcps_topic_take(manual_setup):
+    dp = manual_setup.dp
     tdr = BuiltinDataReader(dp, BuiltinTopicDcpsTopic)
 
     tp = Topic(dp, 'MessageTopic', Message)


### PR DESCRIPTION
Add a domain tag with the process ID for the built-in topic tests (and also for other tests that use the `Common` or `Manual` fixtures) to avoid interference from concurrent test runs