### PR TITLE
Bump delvewheel version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ before-build = [
 
 # By default there is no repair command on windows set, use delvewheel
 repair-wheel-command = [
-    "pip install delvewheel==0.0.18",
+    "pip install delvewheel==1.10.1",
     "delvewheel repair -w {dest_dir} --no-mangle-all {wheel}"
 ]
 


### PR DESCRIPTION
Building wheels now fails on Windows because of:

    pip install delvewheel==0.0.18 && delvewheel repair -w ...
    Collecting delvewheel==0.0.18
      Downloading delvewheel-0.0.18-py3-none-any.whl.metadata (6.8 kB)
    Collecting pefile (from delvewheel==0.0.18)
      Downloading pefile-2024.8.26-py3-none-any.whl.metadata (1.4 kB)
    Collecting machomachomangler (from delvewheel==0.0.18)
      Downloading machomachomangler-0.0.1-py3-none-any.whl.metadata (14 kB)
    Collecting attrs (from machomachomangler->delvewheel==0.0.18)
      Downloading attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
    Downloading delvewheel-0.0.18-py3-none-any.whl (31 kB)
    Downloading machomachomangler-0.0.1-py3-none-any.whl (70 kB)
    Downloading pefile-2024.8.26-py3-none-any.whl (74 kB)
    Downloading attrs-25.3.0-py3-none-any.whl (63 kB)
    Installing collected packages: pefile, attrs, machomachomangler, delvewheel
    Successfully installed attrs-25.3.0 delvewheel-0.0.18 machomachomangler-0.0.1 pefile-2024.8.26
    Traceback (most recent call last):
      File "...\runpy.py", line 197, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "...\runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "...\delvewheel.exe\__main__.py", line 4, in <module>
      File "...\delvewheel\__main__.py", line 4, in <module>
        from .wheel_repair import WheelRepair
      File "...\delvewheel\wheel_repair.py", line 14, in <module>
        from . import patch_dll
      File "...\delvewheel\patch_dll.py", line 7, in <module>
        import setuptools.msvc
    ModuleNotFoundError: No module named 'setuptools'

    Error: Command pip install delvewheel==0.0.18 && delvewheel repair -w ... failed with code 1.

Delvewheel 0.0.18 is really old, hopefully it gets fixed magically by bumping it to the latest released version.