### PR TITLE
`idl:` CDR compatibility for unbounded `sequences` & `list`

### DIFF
--- a/cyclonedds/idl/_builder.py
+++ b/cyclonedds/idl/_builder.py
@@ -123,8 +123,16 @@ class Builder:
         elif isclass(_type) and (issubclass(_type, IdlBitmask)):
             return BitMaskMachine(_type, get_idl_annotations(_type)["bit_bound"])
         elif get_origin(_type) == list:
+            submachine = cls._machine_for_type(get_args(_type)[0], add_size_header, use_version_2)
+
+            if isinstance(submachine, PrimitiveMachine):
+                return PlainCdrV2SequenceOfPrimitiveMachine(submachine.type)
+
+            if isinstance(submachine, (CharMachine)):
+                add_size_header = False
+
             return SequenceMachine(
-                cls._machine_for_type(get_args(_type)[0], add_size_header, use_version_2),
+                submachine,
                 add_size_header=add_size_header
             )
         elif get_origin(_type) == dict:


### PR DESCRIPTION
According to issue [#2247](https://github.com/eclipse-cyclonedds/cyclonedds/issues/2247), an unbounded sequence and a list of the same subtype have incompatible CDR(v2) as a result of the serialisation operation.
By following thought from https://github.com/eclipse-cyclonedds/cyclonedds/issues/2247#issuecomment-3068601131, this commit changes serialisation steps to follow existing sequence ser. process.