### PR TITLE
bugfix/windows-test-pipeline

### DIFF
--- a/.azure/templates/build-test.yml
+++ b/.azure/templates/build-test.yml
@@ -22,7 +22,7 @@ steps:
     name: install_python
     displayName: Install Python $(python-version)
   - bash: |
-      echo "##vso[task.setvariable variable=pip_cache]$(pip cache dir)"
+      echo "###vso[task.setvariable variable=pip_cache;]$(pip cache dir)"
     displayName: Obtain pip cache path
   - task: Cache@2
     inputs:
@@ -44,32 +44,6 @@ steps:
     displayName: Run Flake8 Linter
     condition: eq(variables['run-fuzzing'], false)
   - pwsh: |
-      $cyclone = "$(Pipeline.Workspace)\cyclone-$(Agent.OS)-Release"
-      Write-Host "##vso[task.setvariable variable=PATH]$cyclone\bin;$env:PATH"
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: Ensure Cyclone bin on PATH (Windows)
-  - pwsh: |
-      $cyclone = "$(Pipeline.Workspace)\cyclone-$(Agent.OS)-Release"
-      $bin = Join-Path $cyclone "bin"
-
-      # Make sure env vars are Windows-style for any consumers
-      Write-Host "##vso[task.setvariable variable=CYCLONEDDS_HOME]$cyclone"
-      Write-Host "##vso[task.setvariable variable=CMAKE_PREFIX_PATH]$cyclone"
-      Write-Host "##vso[task.setvariable variable=PATH]$bin;$env:PATH"
-
-      # Validate the dll can load when bin is an explicit DLL directory
-      python -c "import os, ctypes; os.add_dll_directory(r'$bin'); ctypes.WinDLL(r'$bin\\ddsc.dll'); print('OK: loaded ddsc.dll')"
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: Configure Cyclone DLL search (Windows)
-  - pwsh: |
-      $cyclone = "$(Pipeline.Workspace)\cyclone-$(Agent.OS)-Release"
-      $dll = Join-Path $cyclone "bin\ddsc.dll"
-
-      # dumpbin is usually available on windows-latest after VS tools are present
-      dumpbin /dependents $dll
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: Show ddsc.dll dependents (Windows)
-  - pwsh: |
       choco install openssl.light -y --no-progress
       $opensslBin = "C:\Program Files\OpenSSL-Win64\bin"
       Write-Host "##vso[task.setvariable variable=PATH]$opensslBin;$env:PATH"
@@ -77,7 +51,6 @@ steps:
     displayName: Install OpenSSL (Windows)
   - bash: |
       cd tests
-      printenv | sort
       python -m pytest .. -vv --no-coverage-upload --color=yes
     name: test_cyclonedds_py
     displayName: Run tests for CycloneDDS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,21 +74,9 @@ jobs:
   - download: current
     artifact: cyclone-$(Agent.OS)-Release
   - bash: |
-      set -e
-
-      CYCLONE_DIR="$(Pipeline.Workspace)/cyclone-$(Agent.OS)-Release"
-
-      echo "##vso[task.setvariable variable=CYCLONEDDS_HOME]$CYCLONE_DIR"
-      echo "##vso[task.setvariable variable=CMAKE_PREFIX_PATH]$CYCLONE_DIR"
-
-      echo "1xxx"
-      ls -al "$CYCLONE_DIR/bin"
-      echo "2xxx"
-      ls -al "$CYCLONE_DIR"
-      echo "3xxx"
-      ls -al "$(Pipeline.Workspace)"
-      echo "4xxx"
-      chmod +x "$CYCLONE_DIR/bin/"* || true
+      echo "###vso[task.setvariable variable=CYCLONEDDS_HOME;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)-Release"
+      echo "###vso[task.setvariable variable=CMAKE_PREFIX_PATH;]$(Pipeline.Workspace)/cyclone-$(Agent.OS)-Release"
+      chmod +x $(Pipeline.Workspace)/cyclone-$(Agent.OS)-Release/bin/* || true
     name: set_cyclonedds_home
     displayName: Set CYCLONEDDS_HOME
   - pwsh: |


### PR DESCRIPTION
This PR fixes the execution of windows python tests.

It was not able to load ddsc.dll because it did not found the openssl libs (.dlls).