### PR TITLE
`cli:` show DCPSTopic data if available

### DIFF
--- a/cyclonedds/builtin.py
+++ b/cyclonedds/builtin.py
@@ -157,7 +157,7 @@ _pseudo_handle = 0x7fff0000
 BuiltinTopicDcpsParticipant = BuiltinTopic(_pseudo_handle + 1, DcpsParticipant)
 """Built-in topic, is published to when a new participants appear on the network."""
 
-BuiltinTopicDcpsTopic = BuiltinTopic(_pseudo_handle + 2, DcpsEndpoint)
+BuiltinTopicDcpsTopic = BuiltinTopic(_pseudo_handle + 2, DcpsTopic)
 """
 Built-in topic, is published to when a new topic appear on the network.
 

--- a/cyclonedds/internal.py
+++ b/cyclonedds/internal.py
@@ -497,7 +497,7 @@ except ImportError as e:
 
 dds_infinity: int = _clayer.DDS_INFINITY
 uint32_max: int = _clayer.UINT32_MAX
-feature_typelib = _clayer.HAS_TYPELIB
-feature_type_discovery = _clayer.HAS_TYPE_DISCOVERY
-feature_topic_discovery = _clayer.HAS_TOPIC_DISCOVERY
+feature_typelib: int = _clayer.HAS_TYPELIB
+feature_type_discovery: int = _clayer.HAS_TYPE_DISCOVERY
+feature_topic_discovery: int = _clayer.HAS_TOPIC_DISCOVERY
 dds_domain_default: int = _clayer.DDS_DOMAIN_DEFAULT

--- a/cyclonedds/tools/cli/discovery/ls_discoverables.py
+++ b/cyclonedds/tools/cli/discovery/ls_discoverables.py
@@ -88,6 +88,7 @@ class DTopic(Discoverable):
     name: str
     qos: Qos
     show_qos: bool
+    endpoint: DcpsTopic
     publications: List[DPubSub]
     subscriptions: List[DPubSub]
 
@@ -123,8 +124,11 @@ class DTopic(Discoverable):
     def render(self):
         pubsub = self.subscriptions + self.publications
 
-        if not pubsub:
+        if not pubsub and not self.endpoint:
             return
+
+        typename = self.endpoint.type_name if self.endpoint else pubsub[0].endpoint.type_name
+        type_id = self.endpoint.type_id if self.endpoint else pubsub[0].endpoint.type_id
 
         if self.show_qos:
             common_qos = self.shared_qos(pubsub)
@@ -143,7 +147,6 @@ class DTopic(Discoverable):
             writer_qos_consistent = all(not q.policies for q in writer_qos)
             reader_qos_consistent = all(not q.policies for q in reader_qos)
 
-        typename = pubsub[0].endpoint.type_name
         if not all(t.endpoint.type_name == typename for t in pubsub):
             typename = ":police_car_light: [bold red]Inconsistent, see below[/]"
             typename_consistent = False
@@ -151,7 +154,6 @@ class DTopic(Discoverable):
             typename = f"[bold magenta]{typename}[/]"
             typename_consistent = True
 
-        type_id = pubsub[0].endpoint.type_id
         if not all(t.endpoint.type_id == type_id for t in pubsub):
             type_id = ":police_car_light: [bold orange]Inconsistent, see below[/]"
             type_id_consistent = False

--- a/cyclonedds/tools/cli/discovery/main.py
+++ b/cyclonedds/tools/cli/discovery/main.py
@@ -72,7 +72,18 @@ def ls_discovery(
                     for topic in participant.topics:
                         if topic.name == t.topic_name:
                             topic.qos = t.qos
+                            topic.endpoint = t
                             break
+                    else:
+                        topic = DTopic(
+                            name=t.topic_name,
+                            endpoint=t,
+                            subscriptions=[],
+                            publications=[],
+                            show_qos=show_qos,
+                            qos=topic_qos.get(t.topic_name, core.Qos()),
+                        )
+                        participant.topics.append(topic)
 
                 topic_qos[t.topic_name] = t.qos
 
@@ -105,6 +116,7 @@ def ls_discovery(
             else:
                 topic = DTopic(
                     name=pub.endpoint.topic_name,
+                    endpoint=None,
                     subscriptions=[],
                     publications=[pub],
                     show_qos=show_qos,
@@ -141,6 +153,7 @@ def ls_discovery(
             else:
                 topic = DTopic(
                     name=sub.endpoint.topic_name,
+                    endpoint=None,
                     subscriptions=[sub],
                     publications=[],
                     show_qos=show_qos,
@@ -313,9 +326,13 @@ def type_discovery(
     start = datetime.now()
     end = start + runtime
     while datetime.now() < end and not live.terminate:
-        for t in rdt.take(N=20, condition=rct):
-            if topic_re.match(t.topic_name):
-                discovery_data.topic_qosses.append(t.qos)
+        if internal.feature_topic_discovery:
+            for t in rdt.take(N=20, condition=rct):
+                if topic_re.match(t.topic_name):
+                    discovery_data.topic_qosses.append(t.qos)
+                if t.type_id is not None:
+                    discovery_data.add_type_id(str(), t.type_id)
+                live.entities += 1
 
         for pub in rdw.take(N=20, condition=rcw):
             if topic_re.match(pub.topic_name):

--- a/cyclonedds/tools/ddsls/__init__.py
+++ b/cyclonedds/tools/ddsls/__init__.py
@@ -15,9 +15,12 @@ import json
 import datetime
 import argparse
 
+from cyclonedds import internal
 from cyclonedds.domain import DomainParticipant
 from cyclonedds.builtin import (BuiltinDataReader, BuiltinTopicDcpsParticipant,
-                                BuiltinTopicDcpsSubscription, BuiltinTopicDcpsPublication)
+                                BuiltinTopicDcpsSubscription, BuiltinTopicDcpsPublication,
+                                BuiltinTopicDcpsTopic)
+
 from cyclonedds.util import duration
 from cyclonedds.core import WaitSet, ReadCondition, ViewState, InstanceState, SampleState
 
@@ -50,7 +53,8 @@ class TopicManager:
 
             for sample in samples:
                 if (
-                    (self.topic_type == "PARTICIPANT" and sample.key != self.dp_key)
+                    (self.topic_type == "TOPIC")
+                    or (self.topic_type == "PARTICIPANT" and sample.key != self.dp_key)
                     or (self.topic_type != "PARTICIPANT" and sample.participant_key != self.dp_key)
                 ):
                     self.track_sample(sample)
@@ -107,6 +111,14 @@ class TopicManager:
         if self.topic_type == "PARTICIPANT":
             return {
                 "key": str(sample.key),
+                "qos": sample.qos.asdict()
+            }
+        elif internal.feature_topic_discovery and self.topic_type == "TOPIC":
+            return {
+                "key": str(sample.key),
+                "topic_name": str(sample.topic_name),
+                "type_name": str(sample.type_name),
+                "qos": sample.qos.asdict()
             }
         else:
             return {
@@ -159,6 +171,8 @@ def parse_args(args):
             topic = [["PARTICIPANT", BuiltinTopicDcpsParticipant]]
         elif args.topic == "dcpssubscription":
             topic = [["SUBSCRIPTION", BuiltinTopicDcpsSubscription]]
+        elif args.topic == "dcpstopic":
+            topic = [["TOPIC", BuiltinTopicDcpsTopic]]
         else:
             topic = [["PUBLICATION", BuiltinTopicDcpsPublication]]
 
@@ -166,6 +180,8 @@ def parse_args(args):
         topic = [["PARTICIPANT", BuiltinTopicDcpsParticipant],
                  ["SUBSCRIPTION", BuiltinTopicDcpsSubscription],
                  ["PUBLICATION", BuiltinTopicDcpsPublication]]
+        if internal.feature_topic_discovery:
+            topic.append(["TOPIC", BuiltinTopicDcpsTopic])
     return topic
 
 
@@ -180,7 +196,7 @@ def create_parser(args):
     parser.add_argument("-r", "--runtime", type=float, help="Limit the runtime of the tool, in seconds.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("-a", "--all", action="store_true", help="for all topics")
-    group.add_argument("-t", "--topic", choices=["dcpsparticipant", "dcpssubscription", "dcpspublication"],
+    group.add_argument("-t", "--topic", choices=["dcpsparticipant", "dcpssubscription", "dcpspublication"] + ["dcpstopic"] if internal.feature_topic_discovery else [],
                        help="for one specific topic")
 
     args = parser.parse_args(args)


### PR DESCRIPTION
If topic discovery is enabled fill the discovery endpoints with discovered topic entities (applies for `cyclonedds` and `ddsls` cli-tools).